### PR TITLE
fix: 사진 업로드 비율 수정 (#6)

### DIFF
--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
@@ -24,25 +24,31 @@ export const PhotoFrame = styled.div`
   aspect-ratio: 9 / 16;
   overflow: hidden;
   border-radius: 12px;
-  background: #000;
+  background-color: ${({ theme }) => theme.colors.overlay[100]};
 `;
 
 export const PhotoBlurBackground = styled.div`
   position: absolute;
   inset: 0;
   pointer-events: none;
+  overflow: hidden;
 
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    filter: blur(24px);
     transform: scale(1.08);
-    opacity: 0.75;
-    pointer-events: none;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: #00000033;
+    backdrop-filter: blur(50px);
+    -webkit-backdrop-filter: blur(50px);
   }
 `;
-
 export const PhotoMain = styled.div`
   position: relative;
   width: 100%;

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
@@ -92,7 +92,7 @@ export const MemoAlbumOverlay = styled.div`
 `;
 
 export const BottomContainer = styled.div`
-  padding: 12px 20px 33px;
+  padding: 12px 16px 57px;
   background-color: ${({ theme }) => theme.colors.gray[1000]};
 `;
 

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 export const Container = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -13,14 +14,15 @@ export const Container = styled.div`
 `;
 
 export const PhotoSection = styled.div`
-  position: relative;
-  flex: 1;
+  position: absolute;
+  inset: 0;
   overflow: hidden;
 `;
 
 export const PhotoFrame = styled.div`
   position: relative;
   width: 100%;
+  height: 100%;
   aspect-ratio: 9 / 16;
   overflow: hidden;
   border-radius: 12px;
@@ -50,20 +52,20 @@ export const PhotoBlurBackground = styled.div`
   }
 `;
 export const PhotoMain = styled.div`
-  position: relative;
-  width: 100%;
-  height: 100%;
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
-  pointer-events: none;
+  padding: 0;
 
   img {
     width: 100%;
-    height: auto;
-    max-height: 100%;
+    height: 100%;
     object-fit: contain;
-    pointer-events: none;
+    object-position: center;
+    user-select: none;
+    -webkit-user-drag: none;
   }
 `;
 
@@ -92,8 +94,13 @@ export const MemoAlbumOverlay = styled.div`
 `;
 
 export const BottomContainer = styled.div`
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
   padding: 12px 16px 57px;
   background-color: ${({ theme }) => theme.colors.gray[1000]};
+  z-index: 20;
 `;
 
 export const TooltipWrapper = styled.div`

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
@@ -8,8 +8,6 @@ export const Container = styled.div`
   max-width: ${({ theme }) => theme.layout.maxWidth};
   height: 100dvh;
   background-color: ${({ theme }) => theme.colors.gray[1000]};
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
   overflow: hidden;
 `;
 

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
@@ -4,6 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-width: ${({ theme }) => theme.layout.maxWidth};
   height: 100dvh;
   background-color: ${({ theme }) => theme.colors.gray[1000]};
   border-top-left-radius: 20px;
@@ -17,17 +18,46 @@ export const PhotoSection = styled.div`
   overflow: hidden;
 `;
 
-export const PhotoBackground = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
+export const PhotoFrame = styled.div`
+  position: relative;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 9 / 16;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #000;
+`;
+
+export const PhotoBlurBackground = styled.div`
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    filter: blur(24px);
+    transform: scale(1.08);
+    opacity: 0.75;
+    pointer-events: none;
+  }
+`;
+
+export const PhotoMain = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+
+  img {
+    width: 100%;
+    height: auto;
+    max-height: 100%;
+    object-fit: contain;
+    pointer-events: none;
   }
 `;
 

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
@@ -209,7 +209,7 @@ export default function PhotoEditOverlay({
             </S.PhotoBlurBackground>
 
             <S.PhotoMain>
-              <img src={photoDetail.url} alt={`${photoDetail.id}-photo`} />
+              <img src={photoDetail.url} alt={`photo-${photoDetail.id}`} />
             </S.PhotoMain>
           </S.PhotoFrame>
           <S.TopOverlay>

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
@@ -193,9 +193,9 @@ export default function PhotoEditOverlay({
       transition={{ duration: 0.2 }}
       style={{
         position: 'fixed',
-        top: 0,
-        left: 0,
-        width: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        inset: 0,
         height: '100dvh',
         zIndex: 100,
         overflow: 'hidden',
@@ -203,10 +203,15 @@ export default function PhotoEditOverlay({
     >
       <S.Container>
         <S.PhotoSection>
-          <S.PhotoBackground>
-            <img src={photoDetail.url} alt="" />
-          </S.PhotoBackground>
+          <S.PhotoFrame>
+            <S.PhotoBlurBackground>
+              <img src={photoDetail.url} alt="" />
+            </S.PhotoBlurBackground>
 
+            <S.PhotoMain>
+              <img src={photoDetail.url} alt={`${photoDetail.id}-photo`} />
+            </S.PhotoMain>
+          </S.PhotoFrame>
           <S.TopOverlay>
             <PhotoAddHeader
               left={

--- a/apps/web/src/app/photo/[photoId]/page.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/page.styles.ts
@@ -175,7 +175,7 @@ export const ContainerB = styled.div`
 `;
 
 export const SliderWrapper = styled.div`
-  padding: 8px 0 calc(40px + env(safe-area-inset-bottom, 0px)) 0;
+  padding: 8px 0 calc(37px + env(safe-area-inset-bottom, 0px)) 0;
   margin: 16px -16px 0 -16px;
   background: ${({ theme }) => theme.colors.overlay[100]};
 `;

--- a/apps/web/src/app/photo/[photoId]/page.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/page.styles.ts
@@ -18,25 +18,32 @@ export const PhotoSection = styled.div`
 export const PhotoFrame = styled.div`
   position: relative;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 9 / 16;
   overflow: hidden;
   border-radius: 12px;
-  background: #000;
-  pointer-events: none;
+  background-color: ${({ theme }) => theme.colors.overlay[100]};
 `;
 
 export const PhotoBlurBackground = styled.div`
   position: absolute;
   inset: 0;
+  pointer-events: none;
   overflow: hidden;
 
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    filter: blur(50px);
-    opacity: 0.8;
     transform: scale(1.08);
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: #00000033;
+    backdrop-filter: blur(50px);
+    -webkit-backdrop-filter: blur(50px);
   }
 `;
 

--- a/apps/web/src/app/photo/[photoId]/page.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/page.styles.ts
@@ -99,8 +99,7 @@ export const BottomOverlay = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 115px 16px 0;
-  background: ${({ theme }) => theme.colors.gradient.black2};
+  padding: 0 16px;
   z-index: 10;
 `;
 

--- a/apps/web/src/app/photo/[photoId]/page.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/page.styles.ts
@@ -9,16 +9,54 @@ export const Container = styled.div`
   user-select: none;
 `;
 
-export const PhotoBackground = styled.div<{ $url: string }>`
+export const PhotoSection = styled.div`
   position: absolute;
-  top: 0;
-  left: 0;
+  inset: 0;
+  overflow: hidden;
+`;
+
+export const PhotoFrame = styled.div`
+  position: relative;
   width: 100%;
   height: 100%;
-  background-image: url(${({ $url }) => $url});
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #000;
+  pointer-events: none;
+`;
+
+export const PhotoBlurBackground = styled.div`
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    filter: blur(50px);
+    opacity: 0.8;
+    transform: scale(1.08);
+  }
+`;
+
+export const PhotoMain = styled.div`
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  z-index: 1;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    object-position: center;
+    user-select: none;
+    -webkit-user-drag: none;
+  }
 `;
 
 export const TouchAreaLeft = styled.div`
@@ -54,7 +92,7 @@ export const BottomOverlay = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
-  padding: 115px 16px calc(40px + env(safe-area-inset-bottom, 0px));
+  padding: 115px 16px 0;
   background: ${({ theme }) => theme.colors.gradient.black2};
   z-index: 10;
 `;
@@ -130,9 +168,9 @@ export const ContainerB = styled.div`
 `;
 
 export const SliderWrapper = styled.div`
-  margin-top: 16px;
-  margin-left: -16px;
-  margin-right: -16px;
+  padding: 8px 0 calc(40px + env(safe-area-inset-bottom, 0px)) 0;
+  margin: 16px -16px 0 -16px;
+  background: ${({ theme }) => theme.colors.overlay[100]};
 `;
 
 export const MapPreviewButtonWrapper = styled.div`
@@ -144,7 +182,7 @@ export const MapPreviewButtonWrapper = styled.div`
 export const ThumbnailSlider = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: start;
   gap: 8px;
   padding: 0 16px;
   overflow-x: auto;

--- a/apps/web/src/app/photo/[photoId]/page.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/page.styles.ts
@@ -273,3 +273,11 @@ export const LoadingContainer = styled.div`
   ${({ theme }) => theme.typography.body16Regular}
   color: ${({ theme }) => theme.colors.gray[400]};
 `;
+
+export const EmptySlider = styled.div`
+  padding: 8px 0 calc(37px + env(safe-area-inset-bottom, 0px)) 0;
+  margin: 16px -16px 0 -16px;
+  height: 60px;
+  box-sizing: content-box;
+  background: ${({ theme }) => theme.colors.overlay[100]};
+`;

--- a/apps/web/src/app/photo/[photoId]/page.tsx
+++ b/apps/web/src/app/photo/[photoId]/page.tsx
@@ -305,7 +305,7 @@ export default function PhotoViewPage() {
             )}
 
             {/* 서버 모드: 썸네일 슬라이더 */}
-            {!isPendingMode && photos.length > 1 && (
+            {!isPendingMode && photos.length > 1 ? (
               <S.SliderWrapper>
                 <S.ThumbnailSlider ref={thumbnailContainerRef}>
                   {photos.map((photo, index) => (
@@ -319,6 +319,8 @@ export default function PhotoViewPage() {
                   ))}
                 </S.ThumbnailSlider>
               </S.SliderWrapper>
+            ) : (
+              <S.EmptySlider />
             )}
           </S.BottomOverlay>
         </>

--- a/apps/web/src/app/photo/[photoId]/page.tsx
+++ b/apps/web/src/app/photo/[photoId]/page.tsx
@@ -4,11 +4,8 @@ import AlbumSmallIcon from '@/assets/images/albumSmall.svg';
 // TODO: 2차 MVP에서 반영 예정
 // import CommentIcon from '@/assets/images/comment.svg';
 import DateIcon from '@/assets/images/date.svg';
-import MapPin from '@/assets/images/mapPin.svg';
 import Chip from '@/components/buttons/chip/Chip';
-import FloatingButton from '@/components/buttons/floatingButton/FloatingButton';
 import MenuHeader from '@/components/header/menu/MenuHeader';
-import { ROUTES } from '@/constants/routes';
 import { usePendingPhotoDetail } from '@/hooks/usePendingPhotosViewModel';
 import { formatDate } from '@/utils/formatDate';
 import { getGetPhotoDetailQueryOptions, useGetPhotoDetail } from '@repo/api-client';
@@ -143,10 +140,6 @@ export default function PhotoViewPage() {
       setActivePendingId(null);
       router.back();
     }
-  };
-
-  const handleMoveToMapView = () => {
-    router.push(ROUTES.HOME);
   };
 
   // Pending 사진이 외부에서 제거된 경우 (자동 정리 등) 뒤로 이동
@@ -318,16 +311,6 @@ export default function PhotoViewPage() {
                   ))}
                 </S.ThumbnailSlider>
               </S.SliderWrapper>
-            )}
-
-            {!isPendingMode && !albumIdFromQuery && (
-              <S.MapPreviewButtonWrapper>
-                <FloatingButton
-                  text="지도뷰로 보기"
-                  icon={<MapPin width={16} height={16} />}
-                  onClick={handleMoveToMapView}
-                />
-              </S.MapPreviewButtonWrapper>
             )}
           </S.BottomOverlay>
         </>

--- a/apps/web/src/app/photo/[photoId]/page.tsx
+++ b/apps/web/src/app/photo/[photoId]/page.tsx
@@ -180,7 +180,15 @@ export default function PhotoViewPage() {
 
   return (
     <S.Container {...longPressHandlers}>
-      <S.PhotoBackground $url={resolvedPhotoUrl || ''} />
+      <S.PhotoSection>
+        <S.PhotoBlurBackground>
+          <img src={resolvedPhotoUrl || ''} alt="" />
+        </S.PhotoBlurBackground>
+
+        <S.PhotoMain>
+          <img src={resolvedPhotoUrl || ''} alt={`photo-${resolvedDetail?.id}`} />
+        </S.PhotoMain>
+      </S.PhotoSection>
 
       {!isPendingMode && photos.length > 1 && (
         <>

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
@@ -4,6 +4,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
+  max-width: ${({ theme }) => theme.layout.maxWidth};
   height: 100dvh;
   background-color: ${({ theme }) => theme.colors.gray[1000]};
   border-top-left-radius: 20px;
@@ -17,25 +18,52 @@ export const PhotoSection = styled.div`
   overflow: hidden;
 `;
 
-export const PhotoBackground = styled.div`
-  position: absolute;
-  top: 0;
-  left: 0;
+export const PhotoFrame = styled.div`
+  position: relative;
   width: 100%;
-  height: 100%;
+  aspect-ratio: 9 / 16;
+  overflow: hidden;
+  border-radius: 12px;
+  background: #000;
+`;
+
+export const PhotoBlurBackground = styled.div`
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
+    filter: blur(24px);
+    transform: scale(1.08);
+    opacity: 0.75;
+    pointer-events: none;
+  }
+`;
+
+export const PhotoMain = styled.div`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+
+  img {
+    width: 100%;
+    height: auto;
+    max-height: 100%;
+    object-fit: contain;
+    pointer-events: none;
   }
 `;
 
 export const TopOverlay = styled.div`
   position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
+  inset: 0 0 auto 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -44,9 +72,7 @@ export const TopOverlay = styled.div`
 
 export const MemoAlbumOverlay = styled.div`
   position: absolute;
-  bottom: 0;
-  left: 0;
-  width: 100%;
+  inset: auto 0 0 0;
   padding: 16px;
   box-sizing: border-box;
   display: flex;
@@ -57,7 +83,7 @@ export const MemoAlbumOverlay = styled.div`
 
 export const BottomContainer = styled.div`
   padding: 12px 20px 33px;
-  background-color: ${({ theme }) => theme.colors.gray[1000]};
+  background-color: ${({ theme }) => theme.colors.overlay[100]};
 `;
 
 // 말풍선
@@ -201,7 +227,7 @@ export const MapPreviewButton = styled.button`
   justify-content: center;
   gap: 8px;
   padding: 12px 16px;
-  background: ${({ theme }) => theme.colors.gray[900]};
+  background: ${({ theme }) => theme.colors.blueWhite.bg5};
   border: 1px solid ${({ theme }) => theme.colors.blueWhite.border10};
   border-radius: 999px;
   cursor: pointer;
@@ -211,7 +237,6 @@ export const MapPreviewButton = styled.button`
   }
 
   &:disabled {
-    opacity: 0.4;
     cursor: not-allowed;
   }
 `;
@@ -222,11 +247,12 @@ export const MapIcon = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  color: ${({ theme }) => theme.colors.gray[400]};
 `;
 
 export const MapPreviewText = styled.span`
-  ${({ theme }) => theme.typography.body16Semibold};
-  color: ${({ theme }) => theme.colors.gray[0]};
+  ${({ theme }) => theme.typography.body15Medium};
+  color: ${({ theme }) => theme.colors.gray[200]};
 `;
 
 export const UploadButton = styled.button`
@@ -245,7 +271,7 @@ export const UploadButton = styled.button`
   }
 
   &:disabled {
-    background: ${({ theme }) => theme.colors.gray[700]};
+    background: ${({ theme }) => theme.colors.gray[600]};
     cursor: not-allowed;
   }
 `;
@@ -256,6 +282,11 @@ export const UploadIcon = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  color: ${({ theme }) => theme.colors.gray[1000]};
+
+  &:disabled {
+    color: ${({ theme }) => theme.colors.gray[700]};
+  }
 `;
 
 // 선택된 사진 없음 화면

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
@@ -24,22 +24,29 @@ export const PhotoFrame = styled.div`
   aspect-ratio: 9 / 16;
   overflow: hidden;
   border-radius: 12px;
-  background: #000;
+  background-color: ${({ theme }) => theme.colors.overlay[100]};
 `;
 
 export const PhotoBlurBackground = styled.div`
   position: absolute;
   inset: 0;
   pointer-events: none;
+  overflow: hidden;
 
   img {
     width: 100%;
     height: 100%;
     object-fit: cover;
-    filter: blur(24px);
     transform: scale(1.08);
-    opacity: 0.75;
-    pointer-events: none;
+  }
+
+  &::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: #00000033;
+    backdrop-filter: blur(50px);
+    -webkit-backdrop-filter: blur(50px);
   }
 `;
 

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
@@ -7,8 +7,6 @@ export const Container = styled.div`
   max-width: ${({ theme }) => theme.layout.maxWidth};
   height: 100dvh;
   background-color: ${({ theme }) => theme.colors.gray[1000]};
-  border-top-left-radius: 20px;
-  border-top-right-radius: 20px;
   overflow: hidden;
 `;
 

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.styles.ts
@@ -89,7 +89,7 @@ export const MemoAlbumOverlay = styled.div`
 `;
 
 export const BottomContainer = styled.div`
-  padding: 12px 20px 33px;
+  padding: 12px 16px 57px;
   background-color: ${({ theme }) => theme.colors.overlay[100]};
 `;
 

--- a/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
+++ b/apps/web/src/app/photo/add/note/_components/PhotoNoteOverlay.tsx
@@ -238,9 +238,9 @@ export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
       }}
       style={{
         position: 'fixed',
-        top: 0,
-        left: 0,
-        width: '100%',
+        display: 'flex',
+        justifyContent: 'center',
+        inset: 0,
         height: '100dvh',
         zIndex: 100,
         overflow: 'hidden',
@@ -251,9 +251,15 @@ export default function PhotoNoteOverlay({ onClose }: PhotoNoteOverlayProps) {
       <S.Container>
         {/* 사진 영역 */}
         <S.PhotoSection>
-          <S.PhotoBackground>
-            <img src={selectedPhoto.uri} alt={selectedPhoto.filename} />
-          </S.PhotoBackground>
+          <S.PhotoFrame>
+            <S.PhotoBlurBackground>
+              <img src={selectedPhoto.uri} alt="" />
+            </S.PhotoBlurBackground>
+
+            <S.PhotoMain>
+              <img src={selectedPhoto.uri} alt={selectedPhoto.filename} />
+            </S.PhotoMain>
+          </S.PhotoFrame>
 
           {/* 상단 오버레이 */}
           <S.TopOverlay>

--- a/apps/web/src/theme/colors.ts
+++ b/apps/web/src/theme/colors.ts
@@ -76,6 +76,12 @@ export const colors = {
     border10: 'rgba(226,230,255,0.10)',
   },
 
+  overlay: {
+    50: 'rgba(0,0,0,0.5)',
+    80: 'rgba(0,0,0,0.8)',
+    100: '#000000',
+  },
+
   status: {
     red: {
       50: '#FFF3F4',


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #6 

## 🛠 2. 작업 내용

- 컬러시스템 오버레이 관련 토큰 추가
- 사진 상세 페이지 지도뷰로 보기 버튼 제거
- 사진 관련 페이지 이미지 비율 수정

## 📌 3. 참고 사항
<img width="1176" height="742" alt="image" src="https://github.com/user-attachments/assets/4fd9a791-2bae-4960-ad26-59e4bd3c6ff4" />
<img width="897" height="821" alt="image" src="https://github.com/user-attachments/assets/b02216e7-57fa-440b-be15-562649d7e1cb" />

기존 사진 업로드 및 편집 화면을 데스크탑에서 확인할 때, 화면 전체를 가득 채우는 문제가 있었습니다.
이에 컨테이너에 max-width를 적용하고 레이아웃을 조정해, 모바일 사이즈 너비 안에서 UI가 노출되도록 수정했습니다.

추가로 사진 관련 3개 스타일 파일에서 PhotoFrame, PhotoBlurBackground 등 동일한 스타일을 각각 정의해 사용하고 있습니다.
공통 스타일로 분리하는 컨벤션이 있다면 이후 반영하겠습니다.

## 👀 4. 리뷰 중점 사항

- [x] 사진 업로드, 편집, 상세 페이지 UI가 피그마와 동일하게 보이는지
- [x] UI 변경 이후 사진 업로드, 편집, 상세 조회 기능이 모두 정상 동작하는지
