### PR TITLE
refactor: qa 반영 (사진상세-수정 페이지 디자인 수정, 쿠키 동기화 페이지 추가)

### DIFF
--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.styles.ts
@@ -23,7 +23,6 @@ export const PhotoFrame = styled.div`
   height: 100%;
   aspect-ratio: 9 / 16;
   overflow: hidden;
-  border-radius: 12px;
   background-color: ${({ theme }) => theme.colors.overlay[100]};
 `;
 

--- a/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
+++ b/apps/web/src/app/photo/[photoId]/_components/PhotoEditOverlay.tsx
@@ -6,6 +6,7 @@ import { useGetPhotoDetail } from '@repo/api-client';
 import { motion } from 'framer-motion';
 import { useEffect, useState } from 'react';
 import { STATE_SOURCE } from '../../_constants/stateSource';
+import { TOOLTIP_TEXT } from '../../_constants/tooltipText';
 import { usePhotoContext } from '../../_contexts/PhotoContext';
 import AlbumSelectOverlay from '../../add/note/_components/AlbumSelectOverlay';
 import LocationSelectOverlay from '../../add/note/_components/LocationSelectOverlay';
@@ -172,17 +173,20 @@ export default function PhotoEditOverlay({
 
   const isMemoModified = memo !== (photoDetail.description || '');
   const isAlbumModified = selectedAlbum !== null || isAlbumCleared;
-  const isLocationModified = selectedLocation !== null;
+  const isLocationModified =
+    selectedLocation !== null &&
+    (selectedLocation.latitude !== photoDetail.latitude ||
+      selectedLocation.longitude !== photoDetail.longitude);
   const isModified = isMemoModified || isAlbumModified || isLocationModified;
 
   const getTooltipText = () => {
     if (isModified) {
-      return '위치가 수정되었어요.';
+      return TOOLTIP_TEXT.LOCATION_MODIFIED;
     }
     if (hasLocation) {
-      return '위치가 저장되어 있어요.';
+      return TOOLTIP_TEXT.LOCATION_SAVED;
     }
-    return '위치를 추가해주세요.';
+    return TOOLTIP_TEXT.LOCATION_EMPTY;
   };
 
   return (

--- a/apps/web/src/app/photo/[photoId]/page.styles.ts
+++ b/apps/web/src/app/photo/[photoId]/page.styles.ts
@@ -11,7 +11,13 @@ export const Container = styled.div`
 
 export const PhotoSection = styled.div`
   position: absolute;
-  inset: 0;
+  top: 0;
+  right: 0;
+  bottom: 100px;
+  left: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   overflow: hidden;
 `;
 
@@ -48,8 +54,9 @@ export const PhotoBlurBackground = styled.div`
 `;
 
 export const PhotoMain = styled.div`
-  position: absolute;
-  inset: 0;
+  position: relative;
+  width: 100%;
+  height: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -99,6 +106,7 @@ export const BottomOverlay = styled.div`
   bottom: 0;
   left: 0;
   right: 0;
+  background: ${({ theme }) => theme.colors.gradient.black2};
   padding: 0 16px;
   z-index: 10;
 `;

--- a/apps/web/src/app/photo/_constants/tooltipText.ts
+++ b/apps/web/src/app/photo/_constants/tooltipText.ts
@@ -1,0 +1,5 @@
+export const TOOLTIP_TEXT = {
+  LOCATION_MODIFIED: '위치가 수정되었어요.',
+  LOCATION_SAVED: '위치가 저장되어 있어요.',
+  LOCATION_EMPTY: '위치를 추가해주세요.',
+} as const;

--- a/apps/web/src/app/sync/page.tsx
+++ b/apps/web/src/app/sync/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { saveCoupleStatusCookie } from '@repo/api-client';
+import { ROUTES } from '@/constants/routes';
+
+export default function SyncPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const sync = async () => {
+      try {
+        await saveCoupleStatusCookie();
+      } catch {
+        router.replace(ROUTES.ONBOARDING.START);
+        return;
+      }
+
+      const redirect = searchParams.get('redirect') || ROUTES.HOME;
+      router.replace(redirect);
+    };
+
+    void sync();
+  }, [router, searchParams]);
+
+  return null;
+}

--- a/apps/web/src/app/sync/page.tsx
+++ b/apps/web/src/app/sync/page.tsx
@@ -1,11 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
+import { Suspense, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { saveCoupleStatusCookie } from '@repo/api-client';
 import { ROUTES } from '@/constants/routes';
 
-export default function SyncPage() {
+function SyncContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -26,4 +26,12 @@ export default function SyncPage() {
   }, [router, searchParams]);
 
   return null;
+}
+
+export default function SyncPage() {
+  return (
+    <Suspense>
+      <SyncContent />
+    </Suspense>
+  );
 }

--- a/apps/web/src/components/buttons/chip/Chip.styles.ts
+++ b/apps/web/src/components/buttons/chip/Chip.styles.ts
@@ -9,10 +9,14 @@ const variantStyles = {
   black: (theme: Theme) => css`
     background: ${theme.colors.gray.a80};
     color: ${theme.colors.text.primary};
+    backdrop-filter: ${theme.effects.backdropBlur[5]};
+    -webkit-backdrop-filter: ${theme.effects.backdropBlur[5]};
   `,
   white: (theme: Theme) => css`
     background: ${theme.colors.blueWhite.bg5};
     color: ${theme.colors.gray[0]};
+    backdrop-filter: ${theme.effects.backdropBlur[25]};
+    -webkit-backdrop-filter: ${theme.effects.backdropBlur[25]};
   `,
 };
 

--- a/apps/web/src/constants/routes.ts
+++ b/apps/web/src/constants/routes.ts
@@ -26,4 +26,5 @@ export const ROUTES = {
   RECONNECT: '/reconnect',
   DISCONNECT: '/disconnect',
   SIGNOUT: '/signout',
+  SYNC: '/sync',
 } as const;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -24,6 +24,17 @@ export function middleware(request: NextRequest) {
   }
 
   const isOnboarding = pathname.startsWith(ROUTES.ONBOARDING.START);
+  const isSyncPage = pathname === ROUTES.SYNC;
+
+  // coupleStatus 쿠키 없음 → /sync에서 쿠키 동기화 후 원래 경로로 복귀
+  if (!coupleStatus) {
+    if (isSyncPage) {
+      return NextResponse.next();
+    }
+    const syncUrl = new URL(ROUTES.SYNC, request.url);
+    syncUrl.searchParams.set('redirect', pathname);
+    return NextResponse.redirect(syncUrl);
+  }
 
   switch (coupleStatus) {
     case COUPLE_STATUS.COUPLED:
@@ -63,7 +74,7 @@ export function middleware(request: NextRequest) {
       break;
 
     default:
-      // coupleStatus 쿠키 없음 → NOT_COUPLED으로 간주
+      // /sync에서 쿠키 동기화 실패 시 fallback → NOT_COUPLED로 간주
       if (!isOnboarding) {
         return NextResponse.redirect(new URL(ROUTES.ONBOARDING.START, request.url));
       }


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #8 

## 🛠 2. 작업 내용

### 사진 상세
#### 사진 상세 페이지에서 backdrop 추가
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/ec10283b-6ba3-493e-b024-5a7c95c219a1" width="300" /> | <img src="https://github.com/user-attachments/assets/1d1ccc1e-b618-4d0b-acdb-2132754cfe66" width="300" /> |


#### 사진 상세 페이지에서 이미지가 슬라이더를 제외하고 중앙에 위치하도록 레이아웃 수정
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/3658dbfc-aeff-464b-87f5-cfd781b631cc" width="300" /> | <img src="https://github.com/user-attachments/assets/13e1165d-8f2c-4d80-add5-f651b4348e0f" width="300" /> |


### 사진 수정
#### 사진 수정 페이지 불필요한 border-radius
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/4d98df79-eadc-4aaa-aeb0-2f2c9172d9ea" width="300" /> | <img src="https://github.com/user-attachments/assets/202db996-f7da-47d8-b221-50d42c09848f" width="300" /> |

#### 사진 수정 시 위치가 실제로 변경된 경우에만 수정된 것으로 판단하도록 로직 개선
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/10f6e3c8-3b54-4bc2-83a4-4904e420be1f" width="300" />  | <img src="https://github.com/user-attachments/assets/78e5e552-02e7-489c-ad32-0a7303676f50" width="300" />|

### 다른 기기에서 커플 상태가 동기화되지 않는 무제 해결
#### 현상

시크릿 모드, 모바일 등 새 세션에서 접속하면 이미 커플 연결이 되어있음에도 온보딩 화면이 노출됨
#### 원인

coupleStatus 쿠키가 온보딩 완료, 연결 해제, 마이페이지 진입 등 사용자 액션 시에만 세팅되어, 새 세션에서는 쿠키가 존재하지 않음
middleware가 쿠키 없음을 `NOT_COUPLED`로 간주하여 온보딩으로 리다이렉트
#### 해결

쿠키 동기화 전용 `/sync` 페이지를 추가
middleware에서 coupleStatus 쿠키가 없으면 `/sync?redirect={원래경로}`로 리다이렉트
/sync 페이지에서 saveCoupleStatusCookie() API를 호출하여 서버로부터 현재 커플 상태를 조회하고 쿠키를 세팅
성공 시 원래 요청 경로로 복귀, 실패 시 온보딩으로 이동

## 📌 3. 참고 사항

- 기존에는 `coupleStatus` 쿠키가 없으면 middleware에서 `NOT_COUPLED`로 간주하여 온보딩으로 리다이렉트했음
- 쿠키는 온보딩 완료/연결 해제/마이페이지 진입 등 사용자 액션 시에만 세팅되어, 새 세션에서는 항상 누락됨
- `/sync` 페이지에서 `saveCoupleStatusCookie()` 호출 후 원래 경로로 replace, 실패 시 온보딩으로 이동

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [x] middleware에서 쿠키 없을 때 `/sync`로 리다이렉트하는 흐름이 적절한지
- [x] `/sync` 페이지에서 API 실패 시 온보딩으로 이동하는 fallback 처리가 적절한지

## 🧪 5. 테스트

- [x] 기존 세션에서 정상 동작 확인
- [x] 시크릿 모드에서 커플 상태가 정상 반영되는지 확인
- [x] 쿠키 삭제 후 접속 시 무한 리다이렉트 없이 정상 동작하는지 확인

**테스트 방법**

1. 커플 연결이 완료된 계정으로 시크릿 모드에서 접속
2. 온보딩이 아닌 홈 화면으로 정상 진입되는지 확인
