### PR TITLE
Refactor/#16 design qa

### DIFF
--- a/apps/web/src/app/_components/MapRouteHeader.tsx
+++ b/apps/web/src/app/_components/MapRouteHeader.tsx
@@ -32,6 +32,7 @@ export const MapRouteHeader = ({
   return (
     <ExploreHeader
       title={title}
+      showLocationIcon={!isAlbumDetail}
       onClickMenu={onOpenSidebar}
       rightSlot={
         isAlbumDetail && onRenameAlbum && onDeleteAlbum ? (

--- a/apps/web/src/app/onboarding/_components/ProfileImageUpload/ProfileImageUpload.styles.ts
+++ b/apps/web/src/app/onboarding/_components/ProfileImageUpload/ProfileImageUpload.styles.ts
@@ -46,8 +46,8 @@ export const CameraButton = styled.button`
   position: absolute;
   width: 28px;
   height: 28px;
-  right: -4px;
-  bottom: -4px;
+  right: 3px;
+  bottom: 3px;
   border-radius: 50%;
   border: 1px solid ${({ theme }) => theme.colors.blueWhite.border10};
   background: ${({ theme }) => theme.colors.blueWhite.bg8};

--- a/apps/web/src/app/onboarding/connect/page.styles.ts
+++ b/apps/web/src/app/onboarding/connect/page.styles.ts
@@ -63,6 +63,13 @@ export const Content = styled.div`
   gap: 24px;
 `;
 
+export const HeadingGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+`;
+
 export const BackButton = styled.button`
   align-self: flex-start;
   background: none;
@@ -89,6 +96,7 @@ export const Description = styled.p`
   ${({ theme }) => theme.typography.body18Medium};
   color: ${({ theme }) => theme.colors.text.primary};
   text-align: center;
+  margin: 0;
 `;
 
 export const CodeSection = styled.div`

--- a/apps/web/src/app/onboarding/connect/page.styles.ts
+++ b/apps/web/src/app/onboarding/connect/page.styles.ts
@@ -25,7 +25,7 @@ export const Wrapper = styled.div`
   flex-direction: column;
   justify-content: space-between;
   align-items: center;
-  min-height: 100vh;
+  min-height: 100dvh;
   padding: 0;
   background-color: ${({ theme }) => theme.colors.gray[1000]};
   overflow: hidden;
@@ -33,19 +33,25 @@ export const Wrapper = styled.div`
   &::before {
     content: '';
     position: absolute;
-    width: 450px;
-    height: 450px;
-    top: 90px;
-    left: 50%;
-    transform: translateX(-50%);
-    background: linear-gradient(
-      180deg,
-      rgba(213, 255, 253, 0.1) 0%,
-      rgba(110, 234, 228, 0.1) 100%
-    );
-    filter: blur(116.35px);
+    inset: 0;
+    background:
+      radial-gradient(
+        68% 42% at 50% 38%,
+        rgba(213, 255, 253, 0.16) 0%,
+        rgba(110, 234, 228, 0.1) 38%,
+        rgba(110, 234, 228, 0.04) 62%,
+        rgba(110, 234, 228, 0) 100%
+      ),
+      linear-gradient(
+        180deg,
+        rgba(213, 255, 253, 0.04) 0%,
+        rgba(110, 234, 228, 0.08) 45%,
+        rgba(110, 234, 228, 0.03) 72%,
+        rgba(110, 234, 228, 0) 100%
+      );
     animation: ${bgBlur} 0.8s ease-in-out;
     z-index: 0;
+    pointer-events: none;
   }
 `;
 

--- a/apps/web/src/app/onboarding/connect/page.tsx
+++ b/apps/web/src/app/onboarding/connect/page.tsx
@@ -137,8 +137,10 @@ export default function ConnectPage() {
     <S.Wrapper>
       <OnboardingHeader />
       <S.Content>
-        <S.Title>함께 사진을 채워봐요</S.Title>
-        <S.Description>로킷을 함께할 파트너를 초대해주세요</S.Description>
+        <S.HeadingGroup>
+          <S.Title>함께 사진을 채워봐요</S.Title>
+          <S.Description>로킷을 함께할 파트너를 초대해주세요</S.Description>
+        </S.HeadingGroup>
 
         <S.CodeSection>
           <S.SectionTitle>내 초대 코드</S.SectionTitle>

--- a/apps/web/src/components/header/explore/ExploreHeader.tsx
+++ b/apps/web/src/components/header/explore/ExploreHeader.tsx
@@ -10,6 +10,8 @@ import * as S from './ExploreHeader.styles';
 export interface ExploreHeaderProps {
   /** 위치 타이틀 */
   title: string;
+  /** 위치 아이콘 표시 여부 */
+  showLocationIcon?: boolean;
   /** ≡ 메뉴(사이드바) 버튼 클릭 이벤트 */
   onClickMenu: () => void;
   /** 알림 버튼 클릭 이벤트 */
@@ -26,6 +28,7 @@ export interface ExploreHeaderProps {
 
 const ExploreHeader = ({
   title,
+  showLocationIcon = true,
   onClickMenu,
   onClickAlarm,
   rightSlot,
@@ -43,9 +46,11 @@ const ExploreHeader = ({
       }
       center={
         <S.LocationWrapper>
-          <S.LocationIconWrapper>
-            <LocationIcon width={16} height={16} />
-          </S.LocationIconWrapper>
+          {showLocationIcon && (
+            <S.LocationIconWrapper>
+              <LocationIcon width={16} height={16} />
+            </S.LocationIconWrapper>
+          )}
           <S.LocationText>
             <CrossfadeText text={title} />
           </S.LocationText>


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #16 

## 🛠 2. 작업 내용

- 앨범 상세 화면에서 상단 헤더에 위치 아이콘이 노출되지 않도록 수정했습니다.
- `ExploreHeader`에 위치 아이콘 노출 여부를 제어하는 `showLocationIcon` prop을 추가하고, 앨범 상세 진입 시에는 해당 값을 `false`로 전달하도록 반영했습니다.
- 온보딩 프로필 화면의 카메라 버튼 위치를 조정해 프로필 이미지 영역 안쪽에 더 자연스럽게 배치되도록 수정했습니다.

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [x] 앨범 상세 화면에서만 위치 아이콘이 숨겨지고, 일반 지도/위치 화면에서는 기존과 동일하게 노출되는지
- [ ] 온보딩 profile 페이지에서 카메라 버튼 위치가 디자인 의도에 맞게 보이는지
- [x] 온보딩 connect 페이지에서 카카오톡 아이콘이 제대로 보이고 gap이 올바르게 수정되었는지

## 🧪 5. 테스트

- [ ]

**테스트 방법**

1.
2.
