### PR TITLE
chore: PR 리뷰 / 로컬 개발 환경 셋업 스크립트 추가

### DIFF
--- a/scripts/dev-down.sh
+++ b/scripts/dev-down.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+# ================================================================
+# dev-down.sh — dev-up.sh로 띄운 환경 종료
+#   - dev 프로세스 종료 (next, metro, react-native 등)
+#   - 8081(metro) / 3000(web) 포트 점유 프로세스 강제 종료
+#   - iOS Simulator / Android 에뮬레이터 종료
+#   - dev-up.sh로 띄운 Terminal.app/iTerm2 창 정리
+# 사용법: ./scripts/dev-down.sh
+# ================================================================
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "❌ git 레포 안에서 실행해주세요."; exit 1; }
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+log()  { echo -e "${GREEN}✔${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC}  $1"; }
+step() { echo -e "\n${GREEN}▶ $1${NC}"; }
+
+# ── 1. dev 프로세스 종료 ─────────────────────────────────────
+step "1/3  dev 프로세스 종료"
+
+KILLED=0
+PATTERNS=(
+  "next-server"
+  "next dev"
+  "pnpm dev:https"
+  "pnpm dev "
+  "react-native start"
+  "react-native run-ios"
+  "react-native run-android"
+  "metro/src/cli"
+)
+
+for pattern in "${PATTERNS[@]}"; do
+  if pgrep -f "$pattern" >/dev/null 2>&1; then
+    pkill -f "$pattern" 2>/dev/null && KILLED=1 || true
+  fi
+done
+
+if [ "$KILLED" = "1" ]; then
+  sleep 1
+  log "dev 프로세스 종료 완료"
+else
+  log "정리할 dev 프로세스 없음"
+fi
+
+# 포트 점유 프로세스 강제 종료 (metro 8081, web 3000)
+for port in 8081 3000; do
+  PORT_PIDS=$(lsof -ti :$port 2>/dev/null | tr '\n' ' ')
+  if [ -n "$PORT_PIDS" ]; then
+    kill -9 $PORT_PIDS 2>/dev/null || true
+    log "포트 $port 점유 프로세스 종료: $PORT_PIDS"
+  fi
+done
+
+# ── 2. iOS Simulator / Android 에뮬레이터 종료 ───────────────
+step "2/3  iOS Simulator / Android 에뮬레이터 종료"
+
+# iOS Simulator
+if pgrep -f "Simulator\.app" >/dev/null 2>&1; then
+  xcrun simctl shutdown all 2>/dev/null || true
+  osascript -e 'tell application "Simulator" to quit' 2>/dev/null || true
+  log "iOS Simulator 종료 요청"
+else
+  log "iOS Simulator 실행 안 됨 — 건너뜀"
+fi
+
+# Android 에뮬레이터 (adb emu kill)
+EMU_LIST=$(adb devices 2>/dev/null | awk '/^emulator-/ {print $1}')
+if [ -n "$EMU_LIST" ]; then
+  for emu in $EMU_LIST; do
+    adb -s "$emu" emu kill 2>/dev/null || true
+  done
+  log "Android 에뮬레이터 종료 요청"
+else
+  # adb로 잡히지 않는 좀비 qemu가 있으면 강제 종료
+  if pgrep -f "qemu-system" >/dev/null 2>&1; then
+    pkill -f "qemu-system" 2>/dev/null || true
+    log "qemu-system 프로세스 강제 종료"
+  else
+    log "Android 에뮬레이터 실행 안 됨 — 건너뜀"
+  fi
+fi
+
+# ── 3. 터미널 창 정리 ────────────────────────────────────────
+step "3/3  터미널 창 정리"
+
+# 매칭 마커:
+#   - 'pnpm dev' (HTTP/HTTPS 둘 다 커버), 'pnpm ios', 'pnpm android' (dev-up.sh가 띄운 탭)
+#   - 'Welcome to Metro' (react-native이 자체 spawn한 metro 서버 창)
+#   - 'EADDRINUSE' (포트 충돌로 멈춘 창)
+
+# 3-1. Terminal.app:
+#   (a) 매칭 탭의 (windowId, tty) 쌍 수집
+#   (b) 추가: launchPackager.command 이름 가진 좀비 윈도우 ID도 수집 (탭 0개로 매칭 불가한 케이스 대응)
+#   (c) TTY 프로세스(셸 포함) kill
+#   (d) 수집한 winId로 직접 close (재매칭 없이)
+WIN_TTY_LIST=$(osascript 2>/dev/null <<'OSAEOF' || echo ""
+set output to ""
+tell application "System Events"
+  if not (exists process "Terminal") then return ""
+end tell
+tell application "Terminal"
+  try
+    repeat with w in (every window)
+      try
+        set wId to id of w
+        set wName to name of w
+        set matched to false
+        try
+          repeat with t in (tabs of w)
+            try
+              set h to history of t
+              if h contains "pnpm dev" or h contains "pnpm ios" or h contains "pnpm android" or h contains "pnpm start" or h contains "Welcome to Metro" or h contains "EADDRINUSE" then
+                set output to output & wId & ":" & (tty of t) & linefeed
+                set matched to true
+              end if
+            end try
+          end repeat
+        end try
+        -- 좀비 윈도우(탭 0개) 또는 launchPackager 이름 매칭 — TTY 없이 close만
+        if not matched and wName contains "launchPackager" then
+          set output to output & wId & ":" & linefeed
+        end if
+      end try
+    end repeat
+  end try
+end tell
+return output
+OSAEOF
+)
+
+WIN_IDS_TO_CLOSE=()
+if [ -n "$WIN_TTY_LIST" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    win_id="${line%%:*}"
+    tty_path="${line#*:}"
+    WIN_IDS_TO_CLOSE+=("$win_id")
+    if [ -n "$tty_path" ]; then
+      PIDS=$(lsof -t "$tty_path" 2>/dev/null || true)
+      if [ -n "$PIDS" ]; then
+        kill -9 $PIDS 2>/dev/null || true
+      fi
+    fi
+  done <<< "$WIN_TTY_LIST"
+  sleep 1
+fi
+
+TERMINAL_CLOSED=0
+if [ ${#WIN_IDS_TO_CLOSE[@]} -gt 0 ]; then
+  UNIQUE_IDS=$(printf '%s\n' "${WIN_IDS_TO_CLOSE[@]}" | sort -u)
+  while IFS= read -r win_id; do
+    [ -z "$win_id" ] && continue
+    if osascript -e "tell application \"Terminal\" to close window id $win_id saving no" 2>/dev/null; then
+      TERMINAL_CLOSED=$((TERMINAL_CLOSED + 1))
+    fi
+  done <<< "$UNIQUE_IDS"
+fi
+log "Terminal.app 창 ${TERMINAL_CLOSED}개 close"
+
+# 3-2. iTerm2: 동일 패턴
+if [ -d "/Applications/iTerm.app" ]; then
+  ITERM_TTY_LIST=$(osascript 2>/dev/null <<'OSAEOF' || echo ""
+set output to ""
+tell application "System Events"
+  if not (exists process "iTerm2") then return ""
+end tell
+tell application "iTerm"
+  try
+    repeat with w in (every window)
+      try
+        repeat with t in (tabs of w)
+          repeat with s in (sessions of t)
+            try
+              set txt to (contents of s)
+              if txt contains "pnpm dev" or txt contains "pnpm ios" or txt contains "pnpm android" or txt contains "pnpm start" or txt contains "Welcome to Metro" or txt contains "EADDRINUSE" then
+                set output to output & (tty of s) & linefeed
+              end if
+            end try
+          end repeat
+        end repeat
+      end try
+    end repeat
+  end try
+end tell
+return output
+OSAEOF
+)
+  if [ -n "$ITERM_TTY_LIST" ]; then
+    while IFS= read -r tty_path; do
+      [ -z "$tty_path" ] && continue
+      PIDS=$(lsof -t "$tty_path" 2>/dev/null || true)
+      if [ -n "$PIDS" ]; then
+        kill -9 $PIDS 2>/dev/null || true
+      fi
+    done <<< "$ITERM_TTY_LIST"
+    sleep 1
+  fi
+
+  ITERM_CLOSED=$(osascript 2>/dev/null <<'OSAEOF' || echo 0
+set closedCount to 0
+tell application "System Events"
+  if not (exists process "iTerm2") then return 0
+end tell
+tell application "iTerm"
+  set winList to (every window)
+  repeat with w in winList
+    set shouldClose to false
+    try
+      repeat with t in (tabs of w)
+        repeat with s in (sessions of t)
+          try
+            set txt to (contents of s)
+            if txt contains "pnpm dev" or txt contains "pnpm ios" or txt contains "pnpm android" or txt contains "pnpm start" or txt contains "Welcome to Metro" or txt contains "EADDRINUSE" then
+              set shouldClose to true
+              exit repeat
+            end if
+          end try
+        end repeat
+        if shouldClose then exit repeat
+      end repeat
+    end try
+    if shouldClose then
+      try
+        close w
+        set closedCount to closedCount + 1
+      end try
+    end if
+  end repeat
+end tell
+return closedCount
+OSAEOF
+)
+  log "iTerm2 창 ${ITERM_CLOSED}개 닫음"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  🧹 리뷰 환경 종료 완료"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/scripts/dev-up.sh
+++ b/scripts/dev-up.sh
@@ -1,0 +1,415 @@
+#!/bin/bash
+# ================================================================
+# dev-up.sh — PR 리뷰/로컬 개발 환경 자동 세팅
+#
+# 동작 순서
+#   1. 브랜치 체크아웃 + git pull
+#   2. 의존성 변경 감지 → pnpm install / pod install (변경 시에만)
+#   3. 기존 dev 프로세스 정리 + Android 에뮬레이터 부팅(Pixel google_apis +
+#      -writable-system 필수, /etc/hosts 매핑을 위해)
+#   4. 터미널 4개 실행: web(https) / metro / iOS / Android
+#   5. Android /etc/hosts 에 local.lokit.co.kr → 10.0.2.2 매핑
+#
+# 사용법:
+#   ./scripts/dev-up.sh [branch-name]   브랜치명 생략 시 현재 브랜치
+#
+# 종료:
+#   ./scripts/dev-down.sh               dev 프로세스/시뮬·에뮬/터미널 정리
+# ================================================================
+
+set -e
+
+ROOT_DIR=$(git rev-parse --show-toplevel 2>/dev/null) || { echo "❌ git 레포 안에서 실행해주세요."; exit 1; }
+WEB_DIR="$ROOT_DIR/apps/web"
+MOBILE_DIR="$ROOT_DIR/apps/mobile"
+MAIN_BRANCH="main"
+ANDROID_HOST="local.lokit.co.kr"
+ANDROID_IP="10.0.2.2"  # Android 에뮬레이터에서 호스트 머신 접근 IP
+
+# ── 디바이스 오버라이드 (값 비우면 자동 선택) ─────────────────
+# 다른 AVD/시뮬레이터를 쓰고 싶을 때만 이 두 상수를 수정하세요.
+#   - Android: google_apis 태그(=Google APIs 이미지)인 AVD 이름.
+#              비워두면 'Pixel*' 우선, 그 외 첫 google_apis AVD 자동 선택.
+#              주의: Google Play 이미지(Tag: google_apis_playstore)는 adb root 차단으로 사용 불가.
+#   - iOS:     `xcrun simctl list devices` 에 보이는 시뮬레이터 이름.
+#              비워두면 react-native run-ios 기본 동작.
+ANDROID_AVD_OVERRIDE=""    # 예: "Nexus_7_API_30"
+IOS_SIMULATOR_OVERRIDE=""  # 예: "iPhone 15 Pro"
+
+ANDROID_DEVICE_ID=""        # ensure_google_apis_emulator가 채움 (예: emulator-5554)
+
+# ── 색상 ──────────────────────────────────────────────────────
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
+log()  { echo -e "${GREEN}✔${NC} $1"; }
+warn() { echo -e "${YELLOW}⚠${NC}  $1"; }
+error(){ echo -e "${RED}✖${NC}  $1"; exit 1; }
+step() { echo -e "\n${GREEN}▶ $1${NC}"; }
+
+# ── 0. 브랜치 결정 (인자 없으면 현재 브랜치) ─────────────────
+BRANCH=$1
+if [ -z "$BRANCH" ]; then
+  BRANCH=$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD)
+  if [ -z "$BRANCH" ] || [ "$BRANCH" = "HEAD" ]; then
+    error "현재 브랜치를 확인할 수 없습니다. 브랜치명을 인자로 전달해주세요."
+  fi
+  warn "브랜치 인자 없음 — 현재 브랜치로 실행: $BRANCH"
+fi
+
+# ── 1. Git fetch + checkout ───────────────────────────────────
+step "1/4  Git checkout: $BRANCH"
+cd "$ROOT_DIR"
+git fetch origin
+git checkout "$BRANCH"
+git pull origin "$BRANCH"
+log "체크아웃 완료"
+
+# ── 2. 패키지 변경 감지 → 선택적 설치 ───────────────────────
+step "2/4  의존성 변경 감지"
+
+PKG_CHANGED=$(git diff "origin/$MAIN_BRANCH"...HEAD -- '**/package.json' 'pnpm-lock.yaml' 2>/dev/null | grep -c "^+" || echo 0)
+POD_CHANGED=$(git diff "origin/$MAIN_BRANCH"...HEAD -- 'apps/mobile/ios/Podfile.lock' 2>/dev/null | grep -c "^+" || echo 0)
+
+if [ "$PKG_CHANGED" -gt 0 ]; then
+  log "package.json / pnpm-lock.yaml 변경 감지 → pnpm install 실행"
+  cd "$ROOT_DIR"
+  pnpm install
+else
+  log "패키지 변경 없음 — pnpm install 건너뜀"
+fi
+
+if [ "$POD_CHANGED" -gt 0 ]; then
+  log "Podfile.lock 변경 감지 → pod install 실행"
+  cd "$MOBILE_DIR/ios"
+  pod install
+  cd "$ROOT_DIR"
+else
+  log "Pod 변경 없음 — pod install 건너뜀"
+fi
+
+# ── google_apis AVD 자동 부팅 ─────────────────────────────────
+# Google Play 이미지는 adb root 차단으로 /etc/hosts 수정 불가.
+# google_apis 태그의 AVD를 찾아 미리 부팅해두면 react-native run-android가 그 디바이스를 사용함.
+ensure_google_apis_emulator() {
+  local SDK="${ANDROID_HOME:-$HOME/Library/Android/sdk}"
+  local EMULATOR_BIN="$SDK/emulator/emulator"
+  local AVDMANAGER="$SDK/cmdline-tools/latest/bin/avdmanager"
+
+  # 이미 떠있는 에뮬레이터 확인
+  # google_apis + writable-system이면 그대로 사용, 그 외엔 종료 후 재부팅
+  local existing
+  existing=$(adb devices 2>/dev/null | awk '/^emulator-/ {print $1; exit}')
+  if [ -n "$existing" ]; then
+    local build_type
+    build_type=$(adb -s "$existing" shell getprop ro.build.type 2>/dev/null | tr -d '\r')
+    if [ "$build_type" = "userdebug" ]; then
+      # writable-system 여부 확인: /system 쓰기 가능?
+      adb -s "$existing" root >/dev/null 2>&1 || true
+      sleep 1
+      local rw_test
+      rw_test=$(adb -s "$existing" shell "touch /system/.lokit-rw-test 2>&1; rm -f /system/.lokit-rw-test 2>&1" 2>&1)
+      if ! echo "$rw_test" | grep -qiE "read-only|permission|EROFS"; then
+        log "이미 google_apis + writable-system 에뮬레이터 실행 중: $existing"
+        ANDROID_DEVICE_ID="$existing"
+        return 0
+      fi
+      warn "기존 google_apis 에뮬레이터($existing)가 -writable-system 없이 부팅됨 — /etc/hosts 수정 불가, 재부팅 진행"
+    else
+      warn "기존 에뮬레이터($existing)가 Google Play 이미지(${build_type:-unknown}) — 종료 후 google_apis로 교체"
+    fi
+    adb -s "$existing" emu kill 2>/dev/null || true
+    sleep 2
+    if pgrep -f "qemu-system" >/dev/null 2>&1; then
+      pkill -f "qemu-system" 2>/dev/null || true
+      sleep 2
+    fi
+  fi
+
+  if [ ! -x "$EMULATOR_BIN" ]; then
+    warn "emulator 바이너리 없음: $EMULATOR_BIN"
+    return 1
+  fi
+  if [ ! -x "$AVDMANAGER" ]; then
+    warn "avdmanager 없음: $AVDMANAGER (Android Studio cmdline-tools 설치 필요)"
+    return 1
+  fi
+
+  # AVD 선택: 오버라이드 우선, 없으면 google_apis 자동 선택
+  local avd_name="$ANDROID_AVD_OVERRIDE"
+  if [ -n "$avd_name" ]; then
+    log "ANDROID_AVD_OVERRIDE 사용: $avd_name"
+  else
+    # Tag/ABI 줄은 "Based on: ... Tag/ABI: <value>" 포맷이라 줄 시작 앵커 없이 매칭
+    # 우선순위: Pixel > 그 외 google_apis (WebView 도메인 설정이 Pixel에서 검증됨)
+    avd_name=$("$AVDMANAGER" list avd 2>/dev/null | awk '
+      /^[[:space:]]*Name:/ { name = $2 }
+      /Tag\/ABI:/ {
+        if ($NF ~ /^google_apis\//) {
+          if (name ~ /^Pixel/ && !pixel) pixel = name
+          else if (!fallback) fallback = name
+        }
+      }
+      END {
+        if (pixel) print pixel
+        else if (fallback) print fallback
+      }
+    ')
+  fi
+
+  if [ -z "$avd_name" ]; then
+    warn "google_apis 태그의 AVD를 찾을 수 없습니다."
+    warn "Android Studio Device Manager에서 'Google APIs' 이미지로 AVD 생성 필요"
+    warn "(또는 dev-up.sh 상단의 ANDROID_AVD_OVERRIDE 에 AVD 이름 직접 지정)"
+    return 1
+  fi
+
+  log "google_apis AVD 자동 선택: $avd_name (백그라운드 부팅 with -writable-system)"
+  nohup "$EMULATOR_BIN" -avd "$avd_name" -writable-system >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+
+  # adb가 디바이스를 인식할 때까지 대기 (max 30s)
+  local emu_id=""
+  for i in $(seq 1 15); do
+    emu_id=$(adb devices 2>/dev/null | awk '/^emulator-/ {print $1; exit}')
+    if [ -n "$emu_id" ]; then
+      log "에뮬레이터 adb 등록 확인: $emu_id"
+      ANDROID_DEVICE_ID="$emu_id"
+      break
+    fi
+    sleep 2
+  done
+  if [ -z "$emu_id" ]; then
+    warn "에뮬레이터가 30초 내에 adb에 등록되지 않음 — pnpm android가 다른 AVD를 띄울 수 있음"
+    return 1
+  fi
+
+  # boot_completed까지 대기 (max 60s) — 부팅 도중 react-native가 default AVD를 추가로 띄우는 것 방지
+  wait_boot() {
+    local target=$1
+    log "에뮬레이터 부팅 완료 대기 중 ($target)..."
+    for i in $(seq 1 30); do
+      local boot
+      boot=$(adb -s "$target" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')
+      if [ "$boot" = "1" ]; then
+        log "에뮬레이터 부팅 완료: $target"
+        return 0
+      fi
+      sleep 2
+    done
+    warn "에뮬레이터 boot_completed 60초 내 미달성"
+    return 1
+  }
+  wait_boot "$emu_id" || true
+
+  # /system writable 만들기 (writable-system + disable-verity + remount)
+  log "/system writable 설정 중 (adb root + remount)..."
+  adb -s "$emu_id" root >/dev/null 2>&1 || true
+  sleep 2
+  local remount_out
+  remount_out=$(adb -s "$emu_id" remount 2>&1 || true)
+  if echo "$remount_out" | grep -qi "succeeded"; then
+    log "adb remount 성공 — /system writable"
+  else
+    # disable-verity + reboot 후 재시도 필요
+    warn "remount 실패 — disable-verity + reboot 후 재시도"
+    adb -s "$emu_id" disable-verity >/dev/null 2>&1 || true
+    adb -s "$emu_id" reboot >/dev/null 2>&1 || true
+    sleep 5
+    # adb 재등록 + boot_completed 다시 대기
+    for i in $(seq 1 15); do
+      adb devices 2>/dev/null | grep -q "^${emu_id}" && break
+      sleep 2
+    done
+    wait_boot "$emu_id" || true
+    adb -s "$emu_id" root >/dev/null 2>&1 || true
+    sleep 2
+    remount_out=$(adb -s "$emu_id" remount 2>&1 || true)
+    if echo "$remount_out" | grep -qi "succeeded"; then
+      log "adb remount 성공 (after disable-verity + reboot)"
+    else
+      warn "adb remount 여전히 실패 — /etc/hosts 자동 설정 불가"
+      warn "remount output: $(echo "$remount_out" | tail -3)"
+    fi
+  fi
+
+  return 0
+}
+
+# ── Android etc/hosts 설정 ────────────────────────────────────
+# 호출 시점에는 에뮬레이터가 이미 부팅 완료된 상태(ensure_google_apis_emulator가 보장)
+# $ANDROID_DEVICE_ID가 비어있으면 adb가 단일 디바이스 자동 선택
+setup_android_hosts() {
+  local adb_target=""
+  if [ -n "$ANDROID_DEVICE_ID" ]; then
+    adb_target="-s $ANDROID_DEVICE_ID"
+  fi
+
+  ROOT_OUT=$(adb $adb_target root 2>&1 || true)
+  if echo "$ROOT_OUT" | grep -qi "production build"; then
+    warn "에뮬레이터가 Google Play 이미지(production build)임 — adb root 차단됨"
+    warn "/etc/hosts 자동 설정 불가. Android Studio Device Manager에서 'Google APIs' 이미지로 AVD 재생성 필요"
+    warn "(앱은 https://local.lokit.co.kr:3000 을 못 띄워요)"
+    return
+  fi
+  sleep 1
+
+  EXISTING=$(adb $adb_target shell "grep '$ANDROID_HOST' /etc/hosts 2>/dev/null" || true)
+  if [ -n "$EXISTING" ]; then
+    log "Android /etc/hosts 이미 설정되어 있음"
+    return
+  fi
+
+  WRITE_OUT=$(adb $adb_target shell "echo '$ANDROID_IP $ANDROID_HOST' >> /etc/hosts" 2>&1 || true)
+  VERIFY=$(adb $adb_target shell "grep '$ANDROID_HOST' /etc/hosts 2>/dev/null" || true)
+  if [ -n "$VERIFY" ]; then
+    log "Android /etc/hosts 설정 완료: $ANDROID_IP $ANDROID_HOST"
+  else
+    warn "Android /etc/hosts 쓰기 실패: ${WRITE_OUT:-권한 부족}"
+    warn "수동 확인: adb $adb_target shell cat /etc/hosts"
+  fi
+}
+
+# ── 3.5. 기존 dev 프로세스 정리 ──────────────────────────────
+step "3/4  기존 dev 프로세스 정리 + 개발 서버 실행"
+
+cleanup_dev_processes() {
+  local killed=0
+  local patterns=(
+    "next-server"
+    "next dev"
+    "pnpm dev:https"
+    "pnpm dev "
+    "react-native start"
+    "react-native run-ios"
+    "react-native run-android"
+    "metro/src/cli"
+  )
+  for pattern in "${patterns[@]}"; do
+    if pgrep -f "$pattern" >/dev/null 2>&1; then
+      pkill -f "$pattern" 2>/dev/null && killed=1 || true
+    fi
+  done
+  if [ "$killed" = "1" ]; then
+    sleep 1
+    log "기존 dev 프로세스 종료 완료"
+  else
+    log "정리할 dev 프로세스 없음"
+  fi
+}
+
+cleanup_dev_processes
+
+# Android 에뮬레이터를 google_apis로 미리 부팅 (pnpm android 전에)
+ensure_google_apis_emulator || true
+
+# ── 개발 서버 실행 ─────────────────────────────────────────────
+# 4 탭/창: web(https), metro, ios(--no-packager), android(--no-packager --deviceId)
+# - metro를 별도 탭으로 미리 띄움 → ios/android의 metro 자동 spawn 비활성 (--no-packager)
+# - android는 --deviceId로 Pixel 명시 → react-native가 default AVD(Nexus) 추가 부팅 방지
+
+ANDROID_FLAGS="--no-packager"
+if [ -n "$ANDROID_DEVICE_ID" ]; then
+  ANDROID_FLAGS="$ANDROID_FLAGS --deviceId $ANDROID_DEVICE_ID"
+fi
+
+IOS_FLAGS="--no-packager"
+if [ -n "$IOS_SIMULATOR_OVERRIDE" ]; then
+  # 시뮬레이터 이름에 공백 가능 → 단일 인용으로 감쌈 (do script가 그대로 셸로 전달)
+  IOS_FLAGS="$IOS_FLAGS --simulator '$IOS_SIMULATOR_OVERRIDE'"
+fi
+
+wait_for_metro() {
+  for i in $(seq 1 20); do
+    if lsof -iTCP:8081 -sTCP:LISTEN >/dev/null 2>&1; then
+      log "Metro 8081 바인드 확인"
+      return 0
+    fi
+    sleep 1
+  done
+  warn "Metro가 20초 내에 8081 포트에 바인드되지 않음 — ios/android가 자체 metro spawn할 수 있음"
+}
+
+launch_iterm_phase1() {
+  osascript <<EOF
+tell application "iTerm"
+  activate
+  tell current window
+    set webTab to (create tab with default profile)
+    tell current session of webTab
+      write text "cd '$WEB_DIR' && pnpm dev:https"
+    end tell
+    set metroTab to (create tab with default profile)
+    tell current session of metroTab
+      write text "cd '$MOBILE_DIR' && pnpm start"
+    end tell
+  end tell
+end tell
+EOF
+}
+
+launch_iterm_phase2() {
+  osascript <<EOF
+tell application "iTerm"
+  tell current window
+    set iosTab to (create tab with default profile)
+    tell current session of iosTab
+      write text "cd '$MOBILE_DIR' && pnpm ios -- $IOS_FLAGS"
+    end tell
+    set androidTab to (create tab with default profile)
+    tell current session of androidTab
+      write text "cd '$MOBILE_DIR' && pnpm android -- $ANDROID_FLAGS"
+    end tell
+  end tell
+end tell
+EOF
+}
+
+launch_terminal_phase1() {
+  osascript <<EOF
+tell application "Terminal"
+  activate
+  do script "cd '$WEB_DIR' && pnpm dev:https"
+  do script "cd '$MOBILE_DIR' && pnpm start"
+end tell
+EOF
+}
+
+launch_terminal_phase2() {
+  osascript <<EOF
+tell application "Terminal"
+  do script "cd '$MOBILE_DIR' && pnpm ios -- $IOS_FLAGS"
+  do script "cd '$MOBILE_DIR' && pnpm android -- $ANDROID_FLAGS"
+end tell
+EOF
+}
+
+if [ -d "/Applications/iTerm.app" ]; then
+  if launch_iterm_phase1; then
+    log "iTerm2 phase 1 실행 (web + metro)"
+    wait_for_metro
+    launch_iterm_phase2 && log "iTerm2 phase 2 실행 (ios + android)"
+  else
+    warn "iTerm2 실행 실패 — Terminal.app으로 재시도"
+    launch_terminal_phase1
+    wait_for_metro
+    launch_terminal_phase2
+  fi
+else
+  launch_terminal_phase1 && log "Terminal.app phase 1 실행 (web + metro)"
+  wait_for_metro
+  launch_terminal_phase2 && log "Terminal.app phase 2 실행 (ios + android)"
+fi
+
+# ── 5. Android hosts 백그라운드 처리 ─────────────────────────
+step "4/4  Android /etc/hosts 백그라운드 설정"
+setup_android_hosts &
+
+# ── 완료 메시지 ───────────────────────────────────────────────
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  🚀 리뷰 환경 세팅 완료: $BRANCH"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  웹      → 터미널에서 URL 확인"
+echo "  iOS     → 시뮬레이터 자동 실행"
+echo "  Android → 에뮬레이터 자동 실행"
+echo "           (/etc/hosts 백그라운드 설정 중)"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"


### PR DESCRIPTION
## Summary

PR 리뷰 / 로컬 개발 시 web · metro · iOS · Android 환경을 한 번에 띄우고 정리하는 스크립트 두 개 추가.

- `./scripts/dev-up.sh [branch]` — 환경 시작
- `./scripts/dev-down.sh` — 환경 종료

## dev-up.sh 동작

1. **브랜치 체크아웃 + pull** (인자 생략 시 현재 브랜치)
2. **의존성 변경 감지** — `**/package.json`, `pnpm-lock.yaml`, `Podfile.lock` 변경 시에만 `pnpm install` / `pod install`
3. **기존 dev 프로세스 정리** (`next-server`, `metro`, `react-native run-*` 등)
4. **Android 에뮬레이터 자동 부팅**
   - 기존 에뮬레이터가 google_apis + writable-system이면 재사용
   - 그 외(Google Play 이미지 / writable-system 없이 부팅됨)면 종료 후 재부팅
   - AVD 자동 선택: `Pixel*` 우선, 없으면 다른 google_apis AVD
   - **`-writable-system`** 플래그로 부팅 → boot_completed 대기 → `adb root` → `adb remount` (필요 시 `disable-verity` + reboot 1회 사이클)
5. **터미널 4개 실행 (Terminal.app / iTerm2 자동 감지)**
   - Phase 1: `pnpm dev:https` (web), `pnpm start` (metro)
   - Metro가 8081 바인드할 때까지 대기
   - Phase 2: `pnpm ios -- --no-packager`, `pnpm android -- --no-packager --deviceId emulator-XXXX`
   - `--no-packager` + 명시적 deviceId로 metro 자동 spawn 창 / 불필요한 default AVD(Nexus 등) 추가 부팅 방지
6. **`/etc/hosts` 매핑** — 에뮬레이터 안에 `10.0.2.2  local.lokit.co.kr` 추가 → 호스트 머신의 web dev 서버를 도메인으로 접근 가능

## dev-down.sh 동작

1. dev 프로세스 종료 (위와 동일 패턴) + 포트 8081 / 3000 점유 PID 강제 kill
2. iOS Simulator 종료 (`xcrun simctl shutdown all` + Simulator.app quit), Android 에뮬레이터 종료 (`adb emu kill`, qemu 좀비는 `pkill`)
3. dev-up.sh가 띄운 Terminal.app / iTerm2 창 정리 — 탭의 스크롤백 history에서 `pnpm dev`, `pnpm ios`, `pnpm android`, `pnpm start`, `Welcome to Metro`, `EADDRINUSE` 마커 매칭 → 해당 윈도우 ID로 close

## 사전 요구사항

| 항목 | 비고 |
|---|---|
| pnpm | 모노레포 관리 |
| Xcode + iOS Simulator | iOS 빌드 |
| Android Studio + cmdline-tools | `emulator`, `avdmanager` 사용 |
| **Google APIs 이미지의 AVD** (Pixel 권장) | Google Play 이미지는 production build → `adb root` 차단됨, 사용 불가 |
| macOS `/etc/hosts`에 `127.0.0.1 local.lokit.co.kr` | web 도메인 접근용. 없으면 추가 필요 |
| `mkcert` (선택) | `pnpm dev:https`가 첫 실행 시 자동 설정 |

## 디바이스 오버라이드

다른 AVD/시뮬레이터를 쓰고 싶으면 [`scripts/dev-up.sh`](scripts/dev-up.sh) 상단의 두 상수 수정:

```bash
ANDROID_AVD_OVERRIDE=""    # 예: "Nexus_7_API_30" (반드시 google_apis 태그여야 함)
IOS_SIMULATOR_OVERRIDE=""  # 예: "iPhone 15 Pro"
```

빈 문자열이면 자동 선택 로직 사용.

## FAQ / 트러블슈팅

- **`https://local.lokit.co.kr:3000` 안 열림**
  1. 웹 터미널에서 빌드 에러 확인 (Module not found 등 → 코드 수정)
  2. 첫 실행 시 자체 서명 인증서 경고 → "고급 → 계속 진행"
  3. macOS `/etc/hosts`에 `127.0.0.1 local.lokit.co.kr` 있는지

- **`Error: listen EADDRINUSE: address already in use :::8081`** — 이전 metro가 살아있음. `./scripts/dev-down.sh` 한 번 돌리고 다시 dev-up

- **Android 에뮬레이터에서 도메인 못 띄움**
  1. `adb shell cat /etc/hosts`로 `10.0.2.2 local.lokit.co.kr` 매핑 있는지 확인
  2. 없으면 `adb shell mount | grep ' /system '`로 `ro` 인지 `rw` 인지 확인. `ro`면 `-writable-system` 부팅 안 된 거 → `dev-down.sh` 후 다시 dev-up
  3. AVD가 Google Play 이미지인지 확인 (`adb shell getprop ro.build.type` = `user`이면 Play, `userdebug`여야 함)

- **불필요한 Nexus가 추가로 뜸** — `dev-up.sh`가 deviceId 명시로 막아주지만, AVD 자동 선택이 의도와 다르면 `ANDROID_AVD_OVERRIDE`로 강제 지정

- **터미널 창이 5개 이상 뜸** — `dev-down.sh`로 정리 후 재실행. Metro 자동 spawn 창이 끼어든 케이스 (`--no-packager`로 막힘)

## Test plan
- [ ] `./scripts/dev-up.sh` 실행 → web / metro / iOS / Android 4 터미널 정상 기동
- [ ] iOS Simulator에서 앱 진입 + WebView가 `https://local.lokit.co.kr:3000` 로드
- [ ] Android 에뮬레이터에서 앱 진입 + WebView가 동일 도메인 로드 (도메인 에러 없음)
- [x] `./scripts/dev-down.sh` 실행 → 모든 dev 프로세스 / 시뮬·에뮬 / 터미널 창 종료
- [ ] `dev-up.sh` 재실행 시 idempotent — 잔존 프로세스 자동 정리 후 정상 기동
- [ ] `ANDROID_AVD_OVERRIDE` / `IOS_SIMULATOR_OVERRIDE` 변경 시 해당 디바이스로 부팅

🤖 Generated with [Claude Code](https://claude.com/claude-code)