### PR TITLE
feat: 사진 추가 시 카메라 촬영 옵션 추가

### DIFF
--- a/apps/mobile/bridge/handlers/handlePickImage.ts
+++ b/apps/mobile/bridge/handlers/handlePickImage.ts
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import { launchImageLibrary } from 'react-native-image-picker';
+import { launchCamera, launchImageLibrary } from 'react-native-image-picker';
 import type { PhotoQuality } from 'react-native-image-picker';
 import type WebView from 'react-native-webview';
 import {
@@ -18,15 +18,26 @@ export async function handlePickImage(
 ) {
   const { requestId, options } = request;
   try {
-    const result = await launchImageLibrary({
-      mediaType: 'photo',
-      selectionLimit: options?.selectionLimit ?? 1,
+    const commonOptions = {
+      mediaType: 'photo' as const,
       maxWidth: options?.maxWidth ?? DEFAULT_MAX_DIMENSION,
       maxHeight: options?.maxHeight ?? DEFAULT_MAX_DIMENSION,
       quality: (options?.quality as PhotoQuality | undefined) ?? DEFAULT_QUALITY,
       includeBase64: true,
       // EXIF는 웹에서 추출하므로 네이티브에서는 굳이 안 다룸
-    });
+    };
+
+    const result =
+      options?.source === 'camera'
+        ? await launchCamera({
+            ...commonOptions,
+            saveToPhotos: true,
+            cameraType: 'back',
+          })
+        : await launchImageLibrary({
+            ...commonOptions,
+            selectionLimit: options?.selectionLimit ?? 1,
+          });
 
     if (result.didCancel) {
       sendResponse(webViewRef, {

--- a/apps/web/src/app/_components/MapRoute.tsx
+++ b/apps/web/src/app/_components/MapRoute.tsx
@@ -37,8 +37,10 @@ import { AlbumAddModalContainer } from './albumAddModal/AlbumAddModalContainer';
 import { AlbumRenameModalContainer } from './albumRenameModal/AlbumRenameModalContainer';
 import { AlbumDeleteModalContainer } from './albumDeleteModal/AlbumDeleteModalContainer';
 import LocationPermissionModal from './locationPermissionModal/LocationPermissionModal';
+import PhotoSourceSheet from './photoSourceSheet/PhotoSourceSheet';
 import { validateCenterCoordinate } from '../_utils/mapRoute.calc';
 import { saveClusterToSession } from '@/utils/sessionStorage';
+import { checkIsInWebView } from '@/utils/environment';
 import { useLocationPermissionModal } from '@/hooks/useLocationPermissionModal';
 import { usePhotoContext } from '@/app/photo/_contexts/PhotoContext';
 import { usePhotoSelect } from '@/app/photo/add/_hooks/usePhotoSelect';
@@ -118,7 +120,7 @@ export default function MapRoute() {
     ],
   );
 
-  const { selectPhotosFromFile } = usePhotoSelect({
+  const { selectPhotosFromLibrary, selectPhotosFromCamera } = usePhotoSelect({
     onPhotosSelected: handlePhotosSelected,
   });
 
@@ -129,6 +131,7 @@ export default function MapRoute() {
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
   const [isRenameModalOpen, setIsRenameModalOpen] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+  const [isPhotoSourceSheetOpen, setIsPhotoSourceSheetOpen] = useState(false);
   const [menuAlbumId, setMenuAlbumId] = useState<number | undefined>(undefined);
   const [menuAlbumTitle, setMenuAlbumTitle] = useState<string | undefined>(undefined);
 
@@ -312,7 +315,7 @@ export default function MapRoute() {
           {displayPhotos.length === 0 ? (
             <S.EmptyState>
               <HomeEmptyState
-                onAddPhoto={() => selectPhotosFromFile()}
+                onAddPhoto={() => selectPhotosFromLibrary()}
                 onAddAlbum={() => setIsAddModalOpen(true)}
               />
             </S.EmptyState>
@@ -371,7 +374,11 @@ export default function MapRoute() {
             text="사진 추가"
             onClick={() => {
               track('screen_view_photo_picker', { source: 'home' });
-              selectPhotosFromFile();
+              if (checkIsInWebView()) {
+                setIsPhotoSourceSheetOpen(true);
+              } else {
+                selectPhotosFromLibrary();
+              }
             }}
             textAlign="left"
           />
@@ -441,6 +448,12 @@ export default function MapRoute() {
       <LocationPermissionModal
         isOpen={isLocationDeniedModalOpen}
         onClose={handleCloseLocationDeniedModal}
+      />
+      <PhotoSourceSheet
+        isOpen={isPhotoSourceSheetOpen}
+        onClose={() => setIsPhotoSourceSheetOpen(false)}
+        onSelectCamera={selectPhotosFromCamera}
+        onSelectLibrary={selectPhotosFromLibrary}
       />
     </S.Wrapper>
   );

--- a/apps/web/src/app/_components/photoSourceSheet/PhotoSourceSheet.styles.ts
+++ b/apps/web/src/app/_components/photoSourceSheet/PhotoSourceSheet.styles.ts
@@ -1,0 +1,18 @@
+import styled from '@emotion/styled';
+
+export const TextWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+`;
+
+export const Title = styled.h2`
+  ${({ theme }) => theme.typography.heading18Bold};
+  color: ${({ theme }) => theme.colors.grayScale[100]};
+`;
+
+export const Actions = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+`;

--- a/apps/web/src/app/_components/photoSourceSheet/PhotoSourceSheet.tsx
+++ b/apps/web/src/app/_components/photoSourceSheet/PhotoSourceSheet.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import Modal from '@/components/popup/modal/Modal';
+import TextButton from '@/components/buttons/textButton/TextButton';
+import * as S from './PhotoSourceSheet.styles';
+
+interface PhotoSourceSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSelectCamera: () => void;
+  onSelectLibrary: () => void;
+}
+
+const PhotoSourceSheet = ({
+  isOpen,
+  onClose,
+  onSelectCamera,
+  onSelectLibrary,
+}: PhotoSourceSheetProps) => {
+  const handleSelectCamera = () => {
+    onClose();
+    onSelectCamera();
+  };
+
+  const handleSelectLibrary = () => {
+    onClose();
+    onSelectLibrary();
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal.Content>
+        <S.TextWrapper>
+          <S.Title>어떻게 사진을 추가할까요?</S.Title>
+        </S.TextWrapper>
+        <S.Actions>
+          <TextButton text="갤러리에서 선택" onClick={handleSelectLibrary} />
+          <TextButton text="사진 촬영" onClick={handleSelectCamera} />
+        </S.Actions>
+        <Modal.Footer>
+          <TextButton text="취소" onClick={onClose} style={{ flex: 1 }} />
+        </Modal.Footer>
+      </Modal.Content>
+    </Modal>
+  );
+};
+
+export default PhotoSourceSheet;

--- a/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
+++ b/apps/web/src/app/photo/add/_hooks/usePhotoSelect.ts
@@ -1,10 +1,12 @@
 'use client';
 
 import { useCallback, useRef, useState } from 'react';
+import type { PickImageSource } from '@repo/webview-bridge';
 import type { SelectedPhoto } from '../_types/photo';
 import { fileToSelectedPhoto } from '../_utils/fileToSelectedPhoto';
 import { ALLOWED_IMAGE_MIME_TYPES, isAllowedImageType } from '@/constants/image';
 import { requestImageFromBridge } from '@/utils/bridge/requestImageFromBridge';
+import { checkIsInWebView } from '@/utils/environment';
 
 interface UsePhotoSelectOptions {
   onPhotosSelected?: (photos: SelectedPhoto[]) => void;
@@ -13,12 +15,11 @@ interface UsePhotoSelectOptions {
 interface UsePhotoSelectReturn {
   /** 로딩 중 여부 */
   isLoading: boolean;
-  /** 파일 선택으로 사진 추가 */
-  selectPhotosFromFile: () => void;
+  /** 갤러리에서 사진 선택 */
+  selectPhotosFromLibrary: () => void;
+  /** 카메라로 사진 촬영 */
+  selectPhotosFromCamera: () => void;
 }
-
-const isInWebView = () =>
-  typeof window !== 'undefined' && !!window.__lokitBridge && !!window.ReactNativeWebView;
 
 export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectReturn => {
   const [isLoading, setIsLoading] = useState(false);
@@ -34,61 +35,83 @@ export const usePhotoSelect = (options?: UsePhotoSelectOptions): UsePhotoSelectR
     optionsRef.current?.onPhotosSelected?.(newPhotos);
   }, []);
 
-  const selectPhotosFromBridge = useCallback(async () => {
-    setIsLoading(true);
-    try {
-      const picked = await requestImageFromBridge({ selectionLimit: 1 });
-      if (!picked || picked.length === 0) return;
-      await processFiles(picked.map((p) => p.file));
-    } finally {
-      setIsLoading(false);
-    }
-  }, [processFiles]);
-
-  const selectPhotosFromInput = useCallback(() => {
-    const input = document.createElement('input');
-    input.type = 'file';
-    input.accept = ALLOWED_IMAGE_MIME_TYPES.join(',');
-    input.multiple = false;
-    input.style.display = 'none';
-    document.body.appendChild(input);
-
-    const cleanup = () => {
-      document.body.removeChild(input);
-    };
-
-    input.onchange = async (e) => {
-      const files = (e.target as HTMLInputElement).files;
-      if (!files || files.length === 0) {
-        cleanup();
-        return;
-      }
-
+  const selectPhotosFromBridge = useCallback(
+    async (source: PickImageSource) => {
       setIsLoading(true);
       try {
-        await processFiles(Array.from(files));
+        const picked = await requestImageFromBridge({ source, selectionLimit: 1 });
+        if (!picked || picked.length === 0) return;
+        await processFiles(picked.map((p) => p.file));
       } finally {
         setIsLoading(false);
-        cleanup();
       }
-    };
+    },
+    [processFiles],
+  );
 
-    input.oncancel = cleanup;
+  const selectPhotosFromInput = useCallback(
+    (source: PickImageSource) => {
+      const input = document.createElement('input');
+      input.type = 'file';
+      input.accept = ALLOWED_IMAGE_MIME_TYPES.join(',');
+      input.multiple = false;
+      if (source === 'camera') {
+        // 모바일 웹 브라우저에서 후면 카메라로 촬영 모드 유도 (지원하지 않으면 일반 파일 선택으로 폴백)
+        input.capture = 'environment';
+      }
+      input.style.display = 'none';
+      document.body.appendChild(input);
 
-    input.click();
-  }, [processFiles]);
+      const cleanup = () => {
+        document.body.removeChild(input);
+      };
 
-  const selectPhotosFromFile = useCallback(() => {
-    const inWebView = isInWebView();
-    if (inWebView) {
-      void selectPhotosFromBridge();
-    } else {
-      selectPhotosFromInput();
-    }
-  }, [selectPhotosFromBridge, selectPhotosFromInput]);
+      input.onchange = async (e) => {
+        const files = (e.target as HTMLInputElement).files;
+        if (!files || files.length === 0) {
+          cleanup();
+          return;
+        }
+
+        setIsLoading(true);
+        try {
+          await processFiles(Array.from(files));
+        } finally {
+          setIsLoading(false);
+          cleanup();
+        }
+      };
+
+      input.oncancel = cleanup;
+
+      input.click();
+    },
+    [processFiles],
+  );
+
+  const selectPhotos = useCallback(
+    (source: PickImageSource) => {
+      if (checkIsInWebView()) {
+        void selectPhotosFromBridge(source);
+      } else {
+        selectPhotosFromInput(source);
+      }
+    },
+    [selectPhotosFromBridge, selectPhotosFromInput],
+  );
+
+  const selectPhotosFromLibrary = useCallback(
+    () => selectPhotos('library'),
+    [selectPhotos],
+  );
+  const selectPhotosFromCamera = useCallback(
+    () => selectPhotos('camera'),
+    [selectPhotos],
+  );
 
   return {
     isLoading,
-    selectPhotosFromFile,
+    selectPhotosFromLibrary,
+    selectPhotosFromCamera,
   };
 };

--- a/apps/web/src/app/photo/add/page.tsx
+++ b/apps/web/src/app/photo/add/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import { useCallback, type MouseEvent } from 'react';
+import { useCallback, useState, type MouseEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import PlusIcon from '@/assets/images/plus.svg';
 import DefaultHeader from '@/components/header/default/DefaultHeader';
 import PhotoGridContainer from '@/components/photoGridContainer/PhotoGridContainer';
 import PhotoGridItem from '@/components/photoGridItem/PhotoGridItem';
 import { ROUTES } from '@/constants';
+import PhotoSourceSheet from '@/app/_components/photoSourceSheet/PhotoSourceSheet';
+import { checkIsInWebView } from '@/utils/environment';
 import { usePhotoContext } from '../_contexts/PhotoContext';
 import { usePhotoSelect } from './_hooks/usePhotoSelect';
 import type { SelectedPhoto } from './_types/photo';
@@ -44,9 +46,11 @@ export default function PhotoAddPage() {
     [addPhotos, setSelectedPhoto, resetPhotoNoteState, setInitialAlbumId, router],
   );
 
-  const { isLoading, selectPhotosFromFile } = usePhotoSelect({
+  const { isLoading, selectPhotosFromLibrary, selectPhotosFromCamera } = usePhotoSelect({
     onPhotosSelected: handlePhotosSelected,
   });
+
+  const [isPhotoSourceSheetOpen, setIsPhotoSourceSheetOpen] = useState(false);
 
   const handleBack = useCallback(() => {
     router.back();
@@ -78,8 +82,12 @@ export default function PhotoAddPage() {
   );
 
   const handleAddPhotos = useCallback(() => {
-    selectPhotosFromFile();
-  }, [selectPhotosFromFile]);
+    if (checkIsInWebView()) {
+      setIsPhotoSourceSheetOpen(true);
+    } else {
+      selectPhotosFromLibrary();
+    }
+  }, [selectPhotosFromLibrary]);
 
   if (isLoading && photos.length === 0) {
     return (
@@ -108,6 +116,12 @@ export default function PhotoAddPage() {
           ))}
         </PhotoGridContainer>
       </S.Content>
+      <PhotoSourceSheet
+        isOpen={isPhotoSourceSheetOpen}
+        onClose={() => setIsPhotoSourceSheetOpen(false)}
+        onSelectCamera={selectPhotosFromCamera}
+        onSelectLibrary={selectPhotosFromLibrary}
+      />
     </S.Container>
   );
 }

--- a/apps/web/src/utils/environment.ts
+++ b/apps/web/src/utils/environment.ts
@@ -1,0 +1,10 @@
+/**
+ * 현재 클라이언트가 네이티브 앱 WebView 안에서 실행 중인지 판별한다.
+ * - 브리지가 주입되어 있으면 WebView로 간주
+ * - WebView가 아니면(브라우저) `<input type="file">` 경로를 쓰므로
+ *   OS가 자체적으로 카메라/갤러리 선택지를 제공함 → 별도 액션시트 불필요
+ */
+export const checkIsInWebView = (): boolean => {
+  if (typeof window === 'undefined') return false;
+  return !!window.__lokitBridge && !!window.ReactNativeWebView;
+};

--- a/packages/webview-bridge/src/index.ts
+++ b/packages/webview-bridge/src/index.ts
@@ -13,7 +13,11 @@ export type BridgeMessageType = (typeof BRIDGE_MESSAGE_TYPES)[keyof typeof BRIDG
 
 export type BridgeStatus = 'success' | 'cancelled' | 'error';
 
+export type PickImageSource = 'library' | 'camera';
+
 export interface PickImageOptions {
+  /** 'library' = 갤러리에서 선택, 'camera' = 카메라로 촬영. 기본값 'library' */
+  source?: PickImageSource;
   selectionLimit?: number;
   maxWidth?: number;
   maxHeight?: number;


### PR DESCRIPTION
## Summary

- 웹뷰에서 사진 추가 시 **갤러리에서 선택 / 사진 촬영** 액션시트 노출 (기존엔 갤러리만 가능)
- 브리지 프로토콜의 `PickImageOptions`에 `source: 'library' | 'camera'` 추가, 네이티브 핸들러가 `launchCamera`로 분기
- 브라우저 환경(PC/모바일 둘 다)은 OS 자체 파일 피커가 이미 동일 선택지를 제공하므로 액션시트 스킵 → `<input type=\"file\">`로 직행

## 배경

기존 PICK_IMAGE 브리지는 react-native-image-picker의 `launchImageLibrary`만 호출해서, iOS PHPicker / Android PickVisualMedia 같은 갤러리 전용 피커만 떴음. 사용자가 카메라로 바로 촬영할 수 없는 UX였습니다. 이번 변경으로 네이티브 앱에서 액션시트를 통해 카메라 촬영도 가능해졌어요.

브라우저 쪽은 iOS Safari, Android Chrome 모두 `<input type=\"file\" accept=\"image/*\">` 클릭 시 OS가 자체적으로 카메라/갤러리 선택지를 보여주기 때문에, 우리 액션시트는 중복이 됩니다. `checkIsInWebView()`로 분기해서 브라우저는 스킵하도록 했습니다.

## 주요 변경

### 브리지 프로토콜 (`packages/webview-bridge`)
- \`PickImageOptions.source\` 추가 (\`'library' | 'camera'\`, 기본값 \`'library'\`)
- \`PickImageSource\` 타입 export

### 네이티브 (`apps/mobile`)
- \`handlePickImage\`가 \`source === 'camera'\`이면 \`launchCamera\` (saveToPhotos: true, cameraType: back), 아니면 기존대로 \`launchImageLibrary\`
- iOS \`NSCameraUsageDescription\`, Android \`CAMERA\` 권한은 이미 선언되어 있어 추가 작업 없음

### 웹 (`apps/web`)
- \`PhotoSourceSheet\` 신규 컴포넌트 — 기존 Modal 재사용한 액션시트 ([갤러리에서 선택 / 사진 촬영 / 취소])
- \`usePhotoSelect\`: \`selectPhotosFromFile\` → \`selectPhotosFromLibrary\` + \`selectPhotosFromCamera\` 두 함수로 분리
  - 브라우저 폴백은 \`input.capture = 'environment'\`로 후면 카메라 유도 (모바일 브라우저용)
- \`utils/environment.ts\`의 \`checkIsInWebView()\` 추출 (기존 \`usePhotoSelect\` 내부 로컬 헬퍼였던 것 승격)
- [MapRoute.tsx](apps/web/src/app/_components/MapRoute.tsx), [photo/add/page.tsx](apps/web/src/app/photo/add/page.tsx)에서 \`checkIsInWebView\`로 분기해 액션시트 또는 갤러리 직행

홈 빈 상태 카드는 라벨이 \"내 갤러리에서\"로 명시적이라 \`selectPhotosFromLibrary\` 직접 호출 유지.

## Test plan

- [x] **iOS 시뮬레이터 (네이티브 앱)**: 메뉴 \"사진 추가\" → 액션시트 표시 → \"갤러리에서 선택\" 동작 확인 (시뮬레이터는 카메라 없으므로 \"사진 촬영\"은 \`camera_unavailable\` 에러 예상)
- [ ] **iOS 실기기 (네이티브 앱)**: \"사진 촬영\"으로 카메라 앱 열림 + 촬영한 사진이 정보 기입 화면으로 넘어가는지
- [ ] **Android 에뮬레이터/실기기 (네이티브 앱)**: 갤러리/카메라 양쪽 동작
- [x] **iOS Safari / Android Chrome**: \"사진 추가\" 클릭 시 액션시트 안 뜨고 OS 기본 파일 피커가 직접 열리는지
- [x] **PC 브라우저**: 동일 (OS 파일 다이얼로그)
- [x] 홈 빈 상태 카드는 기존대로 갤러리 직행 유지
- [x] [photo/add 페이지](apps/web/src/app/photo/add/page.tsx)의 \"+\" 버튼도 동일 분기로 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)