### PR TITLE
refactor: 헤더 리팩토링 및 홈 격자보기 / 사진 삭제 버그 수정

### DIFF
--- a/apps/web/src/app/_components/MapRoute.tsx
+++ b/apps/web/src/app/_components/MapRoute.tsx
@@ -24,10 +24,12 @@ import { VIEW_CONTEXT_TYPE } from '@/constants/viewContext';
 import { track } from '@/lib/analytics';
 import { useTrackPage } from '@/hooks/analytics/useTrackPage';
 import * as S from '../page.styles';
+import { DEFAULT_LOCATION } from '../constants';
 import { useMapRouteViewState } from '../_hooks/useMapRouteViewState';
 import { useMapRouteViewContext } from '../_hooks/useMapRouteViewContext';
 import { useMapRouteData } from '../_hooks/useMapRouteData';
 import { usePendingPhotosViewModel } from '@/hooks/usePendingPhotosViewModel';
+import { useAlbumPhotos } from '@/hooks/queries/useAlbumPhotos';
 import {
   calculatePhotoCount,
   calculateCenterFromAlbumPhotos,
@@ -80,10 +82,18 @@ export default function MapRoute() {
     selectedAlbumId,
   });
 
+  // HOME 격자보기용 전체사진 앨범 fetch (전체사진 앨범 = albumList[0])
+  const allPhotosAlbumId = albumList[0]?.id ?? null;
+  const { albumDetail: homeGridAlbumDetail } = useAlbumPhotos(
+    viewContext.type === VIEW_CONTEXT_TYPE.HOME ? allPhotosAlbumId : null,
+  );
+
   // Pending 사진 merge (앨범 리스트 + 앨범 상세)
+  const effectiveAlbumDetail =
+    viewContext.type === VIEW_CONTEXT_TYPE.HOME ? homeGridAlbumDetail : albumDetail;
   const { albumList: mergedAlbumList, displayPhotos } = usePendingPhotosViewModel(
     albumList,
-    albumDetail,
+    effectiveAlbumDetail,
   );
 
   // 사진 추가
@@ -135,9 +145,17 @@ export default function MapRoute() {
   const [menuAlbumId, setMenuAlbumId] = useState<number | undefined>(undefined);
   const [menuAlbumTitle, setMenuAlbumTitle] = useState<string | undefined>(undefined);
 
+  const isCustomAlbumSelected =
+    selectedAlbumId != null && selectedAlbumId !== mergedAlbumList[0]?.id;
+
   // 앨범이 선택되었을 때 앨범의 중심 위치로 지도 이동
   useEffect(() => {
     if (!selectedAlbumId) {
+      return;
+    }
+
+    if (!isCustomAlbumSelected) {
+      handleViewStateChange(DEFAULT_LOCATION);
       return;
     }
 
@@ -159,7 +177,13 @@ export default function MapRoute() {
         zoom: centerInfo.zoom,
       });
     }
-  }, [selectedAlbumId, albumDetail, albumMapInfo, handleViewStateChange]);
+  }, [
+    selectedAlbumId,
+    isCustomAlbumSelected,
+    albumDetail,
+    albumMapInfo,
+    handleViewStateChange,
+  ]);
 
   useTrackPage(
     'screen_view_home',
@@ -187,9 +211,6 @@ export default function MapRoute() {
   }, [viewContext, albumDetail, totalHistoryCount]);
 
   const selectedAlbumTitle = albumDetail?.title;
-
-  const isCustomAlbumSelected =
-    selectedAlbumId != null && selectedAlbumId !== mergedAlbumList[0]?.id;
 
   const handlePinClick = async (pin: MapPin) => {
     if (!pin.isCluster) {
@@ -289,7 +310,6 @@ export default function MapRoute() {
         <MapRouteHeader
           viewContext={viewContext}
           selectedAlbumTitle={selectedAlbumTitle}
-          address={address}
           onOpenSidebar={handleOpenSidebar}
           onRenameAlbum={
             isCustomAlbumSelected ? () => handleRenameAlbum(selectedAlbumId) : undefined

--- a/apps/web/src/app/_components/MapRouteHeader.tsx
+++ b/apps/web/src/app/_components/MapRouteHeader.tsx
@@ -6,11 +6,11 @@ import AlbumMenu from '@/components/album-container/albumMenu/AlbumMenu';
 import CircleButton from '@/components/buttons/circleButton/CircleButton';
 import MenuIcon from '@/assets/images/menu.svg';
 import { BUTTON_SIZE, ICON_SIZE } from '@/components/header/base/Header.constants';
+import { DEFAULT_ALBUM_TITLE } from '@/constants';
 
 interface MapRouteHeaderProps {
   viewContext: ViewContext;
   selectedAlbumTitle: string | undefined;
-  address: string | null;
   onOpenSidebar: () => void;
   onRenameAlbum?: () => void;
   onDeleteAlbum?: () => void;
@@ -19,15 +19,12 @@ interface MapRouteHeaderProps {
 export const MapRouteHeader = ({
   viewContext,
   selectedAlbumTitle,
-  address,
   onOpenSidebar,
   onRenameAlbum,
   onDeleteAlbum,
 }: MapRouteHeaderProps) => {
   const isAlbumDetail = viewContext.type === VIEW_CONTEXT_TYPE.ALBUM_DETAIL;
-  const title = isAlbumDetail
-    ? (selectedAlbumTitle ?? '앨범')
-    : address || '위치 정보 로딩 중';
+  const title = selectedAlbumTitle ?? DEFAULT_ALBUM_TITLE;
 
   return (
     <ExploreHeader

--- a/apps/web/src/app/_utils/mapRoute.calc.ts
+++ b/apps/web/src/app/_utils/mapRoute.calc.ts
@@ -3,6 +3,7 @@ import { VIEW_CONTEXT_TYPE } from '@/constants/viewContext';
 import type { ViewContext } from '@/constants/viewContext';
 import type { AlbumWithPhotosResponse, BoundingBoxResponse } from '@repo/api-client';
 import { BBOX_ZOOM_CALCULATION } from '@/constants/map';
+import { DEFAULT_LOCATION } from '../constants';
 
 /**
  * 중심 좌표가 바운딩박스 범위 내에 있는지 검증합니다.
@@ -102,7 +103,7 @@ export const calculateCenterFromBoundingBox = (
             (latDiff * BBOX_ZOOM_CALCULATION.ZOOM_LEVEL_ADJUSTMENT_FACTOR),
         ) - 1
       : BBOX_ZOOM_CALCULATION.DEFAULT_ZOOM;
-  const zoom = Math.max(0, Math.min(lngZoom, latZoom));
+  const zoom = Math.max(DEFAULT_LOCATION.zoom, Math.min(lngZoom, latZoom));
 
   return { longitude, latitude, zoom };
 };

--- a/apps/web/src/app/photo/[photoId]/_hooks/usePhotoDelete.ts
+++ b/apps/web/src/app/photo/[photoId]/_hooks/usePhotoDelete.ts
@@ -5,6 +5,7 @@ import {
   useDelete,
   getGetPhotosQueryKey,
   getGetMapMeQueryKey,
+  getGetPhotoDetailQueryKey,
   type AlbumThumbnails,
   type PhotoListResponse,
 } from '@repo/api-client';
@@ -85,9 +86,22 @@ const usePhotoDelete = () => {
 
     try {
       await deletePhotoAsync({ id: photoId });
+      queryClient.removeQueries({ queryKey: getGetPhotoDetailQueryKey(photoId) });
       queryClient.invalidateQueries({ queryKey: getGetMapMeQueryKey() });
       queryClient.invalidateQueries({ queryKey: getMapMeAlbumsQueryKey() });
-      if (albumId) {
+
+      // 전체 사진 앨범(첫 번째 앨범)은 항상 invalidate
+      const cachedAlbums = queryClient.getQueryData<AlbumThumbnails[]>(
+        getMapMeAlbumsQueryKey(),
+      );
+      const allPhotosAlbumId = cachedAlbums?.[0]?.id;
+      if (allPhotosAlbumId) {
+        queryClient.invalidateQueries({
+          queryKey: getGetPhotosQueryKey(allPhotosAlbumId),
+        });
+      }
+      // 특정 앨범에서 삭제한 경우 해당 앨범도 invalidate
+      if (albumId && albumId !== allPhotosAlbumId) {
         queryClient.invalidateQueries({ queryKey: getGetPhotosQueryKey(albumId) });
       }
     } catch {

--- a/apps/web/src/components/header/explore/ExploreHeader.tsx
+++ b/apps/web/src/components/header/explore/ExploreHeader.tsx
@@ -42,7 +42,6 @@ const ExploreHeader = ({
       }
       center={
         <S.LocationWrapper>
-          <S.LocationArrowIcon />
           <S.LocationText>
             <CrossfadeText text={title} />
           </S.LocationText>

--- a/apps/web/src/components/map/MapView.styels.ts
+++ b/apps/web/src/components/map/MapView.styels.ts
@@ -3,4 +3,8 @@ import styled from '@emotion/styled';
 export const Wrapper = styled.div`
   width: 100%;
   height: 100dvh;
+
+  .mapboxgl-ctrl-logo {
+    display: none !important;
+  }
 `;


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #46 

## 🛠 2. 작업 내용

### fix: 사진 삭제 후 query cache 정리

**문제**  
사진을 삭제하고 이전 화면으로 돌아와도 삭제된 사진이 화면에 그대로 남아 있었습니다.

**원인**
- `albumId`가 URL에 없는 경로(home_map, home_grid)에서 삭제 시 어떤 photos 쿼리도 invalidate되지 않았음
- 삭제된 사진의 photo detail 쿼리가 캐시에 그대로 남아 있었음

**수정**
- 삭제된 사진의 detail 쿼리를 `removeQueries`로 즉시 제거
- 앨범 목록 캐시에서 전체사진 앨범(`albumList[0]`) ID를 조회하여 해당 앨범 쿼리 invalidate
- 특정 앨범에서 삭제 시 해당 앨범 쿼리도 추가 invalidate (전체 앨범 쿼리 오염 방지)

---

### feat: HOME 격자보기 전체사진 앨범 별도 fetch 및 앨범 선택 지도 이동 개선

- HOME 뷰의 격자보기에서 전체사진 앨범(`albumList[0]`)을 별도 fetch하여 올바른 사진 목록 표시
- `effectiveAlbumDetail`로 HOME / 앨범 상세 뷰의 데이터 소스 분리
- 전체사진 앨범 선택 시 지도가 `DEFAULT_LOCATION`으로 초기화되도록 처리
- `isCustomAlbumSelected`를 `useEffect` 의존성에 포함하여 앨범 선택 시 지도 이동 정확도 개선
- `calculateCenterFromBoundingBox`의 최소 zoom을 `0` 대신 `DEFAULT_LOCATION.zoom` 사용

----

### refactor: MapRouteHeader에서 address prop 제거 및 헤더 타이틀 로직 단순화

- `MapRouteHeader`의 `address` prop 제거 — 앨범 타이틀만 표시하도록 단순화
- `ExploreHeader`에서 `LocationArrowIcon` 제거
- 헤더 타이틀을 `DEFAULT_ALBUM_TITLE` 상수 기반으로 통일

---

### refactor: Mapbox 스타일 로고 숨기기

- `MapView` 스타일에서 Mapbox 워터마크 로고 비표시 처리

## 📌 3. 참고 사항

-

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ]

## 🧪 5. 테스트

- [x] 홈에서 mapBox 로고가 보이는지
- [ ] 사진 삭제후 데이터가 남아있지 않은지
- [x] 홈에서 격자보기를 눌럿을 때 올바른 뷰가 뜨는지
- [x] 헤더에서 앨범 정보가 보이는지
