### PR TITLE
fix: access 토큰 만료 시 refresh 기반 자동 재발급 흐름 보정

### DIFF
--- a/apps/web/src/constants/cookie.ts
+++ b/apps/web/src/constants/cookie.ts
@@ -1,4 +1,5 @@
 const COOKIE_PREFIX = process.env.NEXT_PUBLIC_APP_ENV === 'production' ? '' : 'dev-';
 
 export const ACCESS_TOKEN_COOKIE = `${COOKIE_PREFIX}accessToken`;
+export const REFRESH_TOKEN_COOKIE = `${COOKIE_PREFIX}refreshToken`;
 export const COUPLE_STATUS_COOKIE = `${COOKIE_PREFIX}coupleStatus`;

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,17 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { ROUTES } from '@/constants/routes';
-import { ACCESS_TOKEN_COOKIE, COUPLE_STATUS_COOKIE } from '@/constants/cookie';
+import {
+  ACCESS_TOKEN_COOKIE,
+  REFRESH_TOKEN_COOKIE,
+  COUPLE_STATUS_COOKIE,
+} from '@/constants/cookie';
 import { COUPLE_STATUS } from '@/constants/coupleStatus';
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
   const accessToken = request.cookies.get(ACCESS_TOKEN_COOKIE)?.value;
+  const refreshToken = request.cookies.get(REFRESH_TOKEN_COOKIE)?.value;
   const coupleStatus = request.cookies.get(COUPLE_STATUS_COOKIE)?.value;
   const isLoginPage = pathname.startsWith(ROUTES.LOGIN);
+  const isSyncPage = pathname === ROUTES.SYNC;
 
-  // 미인증 → 로그인만 허용
-  if (!accessToken) {
+  // refresh가 세션의 기준점이다. access 쿠키는 짧은 TTL로 먼저 만료돼 사라지지만,
+  // refresh가 살아있으면 다음 API 호출(SSR/클라)에서 백엔드가 토큰을 자동 재발급(Set-Cookie)한다.
+  // 따라서 access 부재만으로 로그인시키지 않고, access·refresh가 모두 없을 때만 미인증으로 본다.
+  if (!accessToken && !refreshToken) {
     if (isLoginPage) {
       return NextResponse.next();
     }
@@ -24,7 +32,6 @@ export function middleware(request: NextRequest) {
   }
 
   const isOnboarding = pathname.startsWith(ROUTES.ONBOARDING.START);
-  const isSyncPage = pathname === ROUTES.SYNC;
 
   // coupleStatus 쿠키 없음 → /sync에서 쿠키 동기화 후 원래 경로로 복귀
   if (!coupleStatus) {

--- a/packages/api-client/src/customFetcher.ts
+++ b/packages/api-client/src/customFetcher.ts
@@ -192,6 +192,8 @@ export async function customFetcher<TResponse>(
   });
 
   if (!response.ok) {
+    // 백엔드는 모든 요청에서 쿠키를 보고 refresh가 살아있으면 토큰을 자동 재발급한다.
+    // 따라서 클라이언트가 401을 받았다면 refresh까지 만료된 것이므로 로그인으로 보낸다.
     if (response.status === 401 && typeof window !== 'undefined') {
       window.location.href = '/login';
     }


### PR DESCRIPTION
## 문제

미들웨어가 `accessToken` 쿠키 **존재 여부만** 확인하고 있었습니다. access 쿠키는 짧은 TTL(`jwt.expiration`)로 refresh보다 먼저 만료돼 브라우저에서 사라지는데, 그 순간 refresh가 살아있어도 곧장 `/login`으로 리다이렉트되어 멀쩡한 세션이 로그아웃되는 문제가 있었습니다.

## 원인 / 배경

[서버](https://github.com/Team-Lokit/lokit-api)의 `AuthenticationFilter`는 **모든 요청**에서 쿠키를 보고, access 만료 + refresh 유효 시 같은 요청에서 토큰을 자동 재발급(Set-Cookie)하고 200을 반환합니다. 즉 **access만 만료된 경우엔 401이 발생하지 않으며**, 클라이언트가 401을 받는 건 refresh까지 만료됐을 때뿐입니다.

하지만 미들웨어는 API를 호출하지 않고 쿠키만 검사하므로 이 투명 재발급의 혜택을 받지 못해, access 쿠키 부재만으로 사용자를 로그인으로 보내고 있었습니다.

## 변경

- **middleware**: 인증 게이트를 `!accessToken` → `!accessToken && !refreshToken`으로 변경. refresh를 세션 기준점으로 삼아, access 쿠키가 먼저 만료돼도 통과시켜 다음 API 호출(SSR/클라)에서 백엔드가 자동 재발급하도록 함
- **cookie**: `REFRESH_TOKEN_COOKIE` 상수 추가 (서버 `DomainCookie.REFRESH_TOKEN`과 일치)
- **customFetcher**: 401은 refresh까지 만료된 경우이므로 `/login`으로 보낸다는 의도 주석 보강 (동작 변경 없음)

## 동작 흐름

- **access만 만료 (refresh 생존)**: 미들웨어 통과 → 다음 API 호출에서 백엔드가 200 + 새 쿠키 → 무중단
- **refresh까지 만료**: API 401 → customFetcher가 `/login`

> access·refresh 쿠키는 httpOnly라 미들웨어(서버사이드)에서만 읽히고 클라 JS는 접근하지 않으므로, access 쿠키가 잠깐 비어도 깨지는 코드는 없습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)