### PR TITLE
fix: 사진 삭제 시 클러스터 및 지도 핀 캐시 invalidate

### DIFF
--- a/apps/web/src/app/photo/[photoId]/_hooks/usePhotoDelete.ts
+++ b/apps/web/src/app/photo/[photoId]/_hooks/usePhotoDelete.ts
@@ -6,6 +6,7 @@ import {
   getGetPhotosQueryKey,
   getGetMapMeQueryKey,
   getGetPhotoDetailQueryKey,
+  getGetClusterPhotosQueryKey,
   type AlbumThumbnails,
   type PhotoListResponse,
 } from '@repo/api-client';
@@ -15,6 +16,7 @@ import { useToast } from '@/components/toast/ToastProvider';
 interface ConfirmDeleteParams {
   photoId: number;
   albumId?: number;
+  clusterId?: string;
 }
 
 const usePhotoDelete = () => {
@@ -33,7 +35,7 @@ const usePhotoDelete = () => {
     setIsModalOpen(false);
   };
 
-  const confirmDelete = async ({ photoId, albumId }: ConfirmDeleteParams) => {
+  const confirmDelete = async ({ photoId, albumId, clusterId }: ConfirmDeleteParams) => {
     // 낙관적 업데이트를 위한 이전 데이터 스냅샷
     const previousAlbums = queryClient.getQueryData<AlbumThumbnails[]>(
       getMapMeAlbumsQueryKey(),
@@ -104,6 +106,13 @@ const usePhotoDelete = () => {
       if (albumId && albumId !== allPhotosAlbumId) {
         queryClient.invalidateQueries({ queryKey: getGetPhotosQueryKey(albumId) });
       }
+      // 클러스터 캐시 invalidate (클러스터 뷰에서 삭제 시 지도에 반영)
+      if (clusterId) {
+        queryClient.invalidateQueries({
+          queryKey: getGetClusterPhotosQueryKey(clusterId),
+        });
+      }
+      queryClient.invalidateQueries({ queryKey: ['mapPhotos'] });
     } catch {
       if (previousAlbums !== undefined) {
         queryClient.setQueryData(getMapMeAlbumsQueryKey(), previousAlbums);

--- a/apps/web/src/app/photo/[photoId]/page.tsx
+++ b/apps/web/src/app/photo/[photoId]/page.tsx
@@ -372,6 +372,7 @@ export default function PhotoViewPage() {
               confirmDelete({
                 photoId: displayPhotoId,
                 albumId: albumIdFromQuery,
+                clusterId: clusterIdFromQuery,
               })
             }
           />


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #49 

## 🛠 2. 작업 내용

- 사진 삭제 시 `clusterId`를 `confirmDelete`에 전달하도록 수정
- 삭제 성공 후 해당 클러스터의 사진 목록 쿼리(`getGetClusterPhotosQueryKey`) invalidate 추가
- 삭제 성공 후 지도 핀 쿼리(`mapPhotos`) 전체 invalidate 추가하여 클러스터 카운트 및 썸네일 갱신

## 📌 3. 참고 사항

- 

## 👀 4. 리뷰 중점 사항

<!-- 논의할 사항이나 중점적으로 리뷰 받고 싶은 사항을 작성해주세요 -->

- [ ]

## 🧪 5. 테스트

- [ ]

**테스트 방법**

1.
2.
