### PR TITLE
fix: 로그인 분석 이벤트 수집 복구 및 유저 식별 보강

### DIFF
--- a/apps/web/src/app/login/_clientBoundary/LoginButtonClient/LoginButtonClient.tsx
+++ b/apps/web/src/app/login/_clientBoundary/LoginButtonClient/LoginButtonClient.tsx
@@ -5,17 +5,29 @@ import AppleIcon from '@/assets/images/apple.svg';
 import KakaoIcon from '@/assets/images/kakao.svg';
 import { API_URL } from '@/constants/apiUrl';
 import { useIsIOS } from '@/hooks/useIsIOS';
+import type { LoginMethod } from '@/lib/analytics/events';
 
 const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
+const LOGIN_PENDING_KEY = 'lokit:loginPending';
+
+function markLoginPending(method: LoginMethod) {
+  try {
+    sessionStorage.setItem(LOGIN_PENDING_KEY, method);
+  } catch {
+    // ignore
+  }
+}
 
 export default function LoginButtonClient() {
   const isIOS = useIsIOS();
 
   const handleKakaoLogin = () => {
+    markLoginPending('kakao');
     window.location.href = `${apiBaseUrl}${API_URL.AUTH.KAKAO}`;
   };
 
   const handleAppleLogin = () => {
+    markLoginPending('apple');
     window.location.href = `${apiBaseUrl}${API_URL.AUTH.APPLE}`;
   };
 

--- a/apps/web/src/app/login/_clientBoundary/LoginTrackerClient/LoginTrackerClient.tsx
+++ b/apps/web/src/app/login/_clientBoundary/LoginTrackerClient/LoginTrackerClient.tsx
@@ -10,7 +10,7 @@ export default function LoginTrackerClient() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const errorCode = params.get('error');
+    const errorCode = params.get('oauth_error');
 
     if (errorCode) {
       track('login_fail', {

--- a/apps/web/src/app/mypage/account/_clientBoundary/LogoutClient/LogoutClient.tsx
+++ b/apps/web/src/app/mypage/account/_clientBoundary/LogoutClient/LogoutClient.tsx
@@ -6,6 +6,7 @@ import { useToast } from '@/components/toast';
 import Modal from '@/components/popup/modal/Modal';
 import TextButton from '@/components/buttons/textButton/TextButton';
 import { ROUTES } from '@/constants/routes';
+import { resetIdentity } from '@/lib/analytics';
 import * as S from './LogoutClient.styles';
 import ChevronRightSmallIcon from '@/assets/images/chevronRightSmall.svg';
 
@@ -16,6 +17,7 @@ export default function LogoutClient() {
   const { mutate: logout, isPending } = useLogout({
     mutation: {
       onSuccess: () => {
+        resetIdentity();
         window.location.href = ROUTES.LOGIN;
       },
       onError: () => {

--- a/apps/web/src/app/signout/_components/CtaContainer/_clientBoundary/SignoutButtonClient/SignoutButtonClient.tsx
+++ b/apps/web/src/app/signout/_components/CtaContainer/_clientBoundary/SignoutButtonClient/SignoutButtonClient.tsx
@@ -8,6 +8,7 @@ import usePopup from '@/hooks/usePopup';
 import { useToast } from '@/components/toast/ToastProvider';
 import { useSignoutContext } from '@/app/signout/_contexts/SignoutContext';
 import { ROUTES } from '@/constants/routes';
+import { resetIdentity } from '@/lib/analytics';
 import * as S from './SignoutButtonClient.styles';
 
 export default function SignoutButtonClient() {
@@ -18,6 +19,7 @@ export default function SignoutButtonClient() {
   const { mutate: withdraw, isPending } = useWithdraw({
     mutation: {
       onSuccess: () => {
+        resetIdentity();
         window.location.href = ROUTES.LOGIN;
       },
       onError: (error) => {

--- a/apps/web/src/app/sync/page.tsx
+++ b/apps/web/src/app/sync/page.tsx
@@ -6,7 +6,7 @@ import { saveCoupleStatusCookie } from '@repo/api-client';
 import { ROUTES } from '@/constants/routes';
 import { COUPLE_STATUS_COOKIE } from '@/constants/cookie';
 import { COUPLE_STATUS } from '@/constants/coupleStatus';
-import { track } from '@/lib/analytics';
+import { track, identify } from '@/lib/analytics';
 import type { LoginMethod } from '@/lib/analytics/events';
 
 const LOGIN_PENDING_KEY = 'lokit:loginPending';
@@ -23,9 +23,9 @@ function readCookie(name: string): string | null {
 function consumeLoginPending(): LoginMethod | null {
   try {
     const value = sessionStorage.getItem(LOGIN_PENDING_KEY);
-    if (value === 'kakao') {
+    if (value === 'kakao' || value === 'apple') {
       sessionStorage.removeItem(LOGIN_PENDING_KEY);
-      return 'kakao';
+      return value;
     }
   } catch {
     // ignore
@@ -48,9 +48,19 @@ function SyncContent() {
 
       const loginMethod = consumeLoginPending();
       if (loginMethod) {
-        const coupleStatus = readCookie(COUPLE_STATUS_COOKIE);
+        const userId = searchParams.get('user_id');
+        if (userId) identify(userId);
+
+        // is_new_user는 백엔드가 redirect로 내려준 값을 우선 사용하고,
+        // (미배포 등) 없을 때만 coupleStatus 기반 근사치로 폴백한다.
+        const isNewUserParam = searchParams.get('is_new_user');
+        const isNewUser =
+          isNewUserParam !== null
+            ? isNewUserParam === 'true'
+            : readCookie(COUPLE_STATUS_COOKIE) === COUPLE_STATUS.NOT_COUPLED;
+
         track('login_success', {
-          is_new_user: coupleStatus === COUPLE_STATUS.NOT_COUPLED,
+          is_new_user: isNewUser,
           login_method: loginMethod,
         });
       }

--- a/apps/web/src/hooks/analytics/useIdentifyUser.ts
+++ b/apps/web/src/hooks/analytics/useIdentifyUser.ts
@@ -1,0 +1,21 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { identify } from '@/lib/analytics';
+
+/**
+ * 세션 시작 시 유저를 Mixpanel에 재식별한다.
+ * - 로그인 직후 1회 identify는 /sync에서 처리되지만, Mixpanel 익명 ID가
+ *   WebView 스토리지 eviction 등으로 초기화될 수 있어, 항상 호출되는
+ *   데이터(/map/me)의 userId로 매 세션 다시 식별한다.
+ * - 같은 userId로의 중복 호출은 ref로 막는다.
+ */
+export function useIdentifyUser(userId?: number | null) {
+  const lastIdentified = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (userId == null || lastIdentified.current === userId) return;
+    lastIdentified.current = userId;
+    identify(String(userId));
+  }, [userId]);
+}

--- a/apps/web/src/hooks/queries/useMapMe.ts
+++ b/apps/web/src/hooks/queries/useMapMe.ts
@@ -5,6 +5,7 @@ import { useMemo, useRef, useState, useEffect } from 'react';
 import Supercluster from 'supercluster';
 import type { MapPin } from '@/types/map.type';
 import { MAP_CLUSTERING_CONFIG } from '@/constants/map';
+import { useIdentifyUser } from '@/hooks/analytics/useIdentifyUser';
 import {
   convertPhotosToGeoJsonFeatures,
   parseBbox,
@@ -71,6 +72,12 @@ export const useMapMe = ({ longitude, latitude, zoom, albumId }: UseMapMeParams)
       setLastDataVersion(response.data.dataVersion);
     }
   }, [response.data?.dataVersion, lastDataVersion]);
+
+  // 세션 시작 시 유저 재식별 (/map/me 응답의 userId 사용).
+  // 백엔드가 userId를 추가했지만 생성된 클라이언트 타입엔 아직 없어 캐스팅한다.
+  // orval 재생성으로 MapMeResponse.userId가 반영되면 캐스팅 제거.
+  const userId = (response.data as { userId?: number } | undefined)?.userId;
+  useIdentifyUser(userId);
 
   const address = useMemo(() => {
     if (!isValid) return '';

--- a/apps/web/src/lib/analytics/events.ts
+++ b/apps/web/src/lib/analytics/events.ts
@@ -6,7 +6,7 @@
 export type ViewMode = 'map' | 'grid';
 export type PhotoDetailSource = 'home_map' | 'home_grid' | 'album_detail';
 export type PhotoPickerSource = 'home' | 'album_detail';
-export type LoginMethod = 'kakao';
+export type LoginMethod = 'kakao' | 'apple';
 export type LoginReferrer = 'organic' | 'deeplink';
 export type InviteMethod = 'link' | 'code';
 export type CoupleConnectErrorType = 'invalid_code' | 'expired' | 'already_connected';

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -40,6 +40,12 @@ export function middleware(request: NextRequest) {
     }
     const syncUrl = new URL(ROUTES.SYNC, request.url);
     syncUrl.searchParams.set('redirect', pathname);
+    // 백엔드가 OAuth 콜백 redirect에 붙인 로그인 파라미터를 /sync까지 넘긴다.
+    // 여기서 버려지면 login_success의 user_id·is_new_user를 잃는다.
+    for (const key of ['user_id', 'is_new_user']) {
+      const value = request.nextUrl.searchParams.get(key);
+      if (value) syncUrl.searchParams.set(key, value);
+    }
     return NextResponse.redirect(syncUrl);
   }
 


### PR DESCRIPTION
## 배경
신규 로그인 시 `login_success` 이벤트가 Mixpanel/GTM에 전혀 수집되지 않는 문제가 있었습니다. 원인은 로그인 시작 시점에 로그인 방식을 `sessionStorage`(`lokit:loginPending`)에 **기록하는 코드가 없어**, OAuth 복귀 후 `/sync`에서 항상 `null`로 읽혀 이벤트가 발생하지 않은 것이었습니다.

이 PR은 그 버그를 고치고, 더불어 그동안 호출되지 않던 유저 식별(`identify`/`resetIdentity`)과 `is_new_user` 정확도까지 함께 보강합니다.

## 변경 사항
- **login_success 복구**: 로그인 버튼 클릭 시 `loginPending` 플래그를 `sessionStorage`에 기록 (`markLoginPending`)
- **카카오/애플 구분**: `LoginMethod`에 `apple` 추가, `/sync`에서 두 방식 모두 소비
- **login_fail 복구**: 프론트가 읽는 쿼리명을 백엔드와 정합 (`error` → `oauth_error`)
- **유저 식별**: 로그인 성공 시 `identify(user_id)`, 로그아웃/회원탈퇴 성공 시 `resetIdentity()`
- **세션 재식별**: `/map/me`의 `userId`로 세션 시작마다 재식별 (`useIdentifyUser`, WebView 스토리지 eviction 대비)
- **is_new_user 정확도**: 백엔드 redirect 쿼리값을 우선 사용, 미배포 시 `coupleStatus` 근사로 폴백
- **미들웨어**: `/sync` 바운스 시 `user_id`·`is_new_user` 쿼리 전달

## ⚠️ 백엔드 의존 (별도 작업 필요)
아래가 반영되면 자동으로 정확해지도록 **하위호환**되게 작성했습니다 (미배포 상태로 머지해도 기존 동작 유지):
1. OAuth 콜백 redirect에 `user_id`·`is_new_user` 쿼리 추가
2. `/map/me` 응답에 본인 `userId` 필드 추가

> `useMapMe`의 `userId`는 생성된 클라이언트 타입에 아직 없어 임시 캐스팅 상태입니다. 백엔드 반영 + orval 재생성 후 캐스팅 제거 예정 (코드 주석 명시).

## 테스트
- `tsc --noEmit` 통과 (web)
- lint-staged(prettier + eslint --max-warnings=0) 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)