### PR TITLE
fix: 불필요한 미디어 읽기 권한 제거 및 버전 업데이트

### DIFF
--- a/apps/mobile/android/app/build.gradle
+++ b/apps/mobile/android/app/build.gradle
@@ -88,8 +88,8 @@ android {
         applicationId "kr.co.lokit"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 1
-        versionName "1.0.0"
+        versionCode 6
+        versionName "1.0.6"
     }
     signingConfigs {
         debug {

--- a/apps/mobile/android/app/src/main/AndroidManifest.xml
+++ b/apps/mobile/android/app/src/main/AndroidManifest.xml
@@ -1,8 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.CAMERA" />
-  <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
-  <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 


### PR DESCRIPTION
## 개요
Google Play Console의 사진/동영상 권한 정책 경고를 해소하기 위해 불필요한 미디어 읽기 권한을 제거합니다.

## 변경 사항
- `READ_MEDIA_IMAGES` / `READ_EXTERNAL_STORAGE` 권한 제거
- versionCode `1` → `6`, versionName `1.0.0` → `1.0.6`

## 권한 제거가 안전한 이유
- 사진 선택(`launchImageLibrary`)은 시스템 선택기(`ACTION_GET_CONTENT` / Photo Picker)를 사용 → 선택한 사진 URI에만 임시 접근 권한을 받으므로 `READ_MEDIA_IMAGES` 불필요
- 사진 촬영(`launchCamera`)은 `CAMERA` 권한으로 동작 (유지됨)
- `react-native-image-picker` 라이브러리 자체는 해당 권한을 선언하지 않음 (FileProvider만 등록)

## 체크리스트
- [ ] 실기기에서 사진 선택 정상 동작 확인
- [ ] 실기기에서 카메라 촬영 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)