### PR TITLE
fix: 격자보기에서 사진 상세 이동 시 albumId 전달 (#57)

### DIFF
--- a/apps/web/src/app/_components/MapRoute.tsx
+++ b/apps/web/src/app/_components/MapRoute.tsx
@@ -361,14 +361,26 @@ export default function MapRoute() {
                         photo_id: String(photo.id),
                         photo_date: photo.takenAt ?? '',
                       });
-                      const url = ROUTES.PHOTO.VIEW(photo.id!);
+
+                      const params = new URLSearchParams();
                       const gridSource =
                         viewContext.type === VIEW_CONTEXT_TYPE.ALBUM_DETAIL
                           ? 'album_detail'
                           : 'home_grid';
-                      router.push(
-                        `${url}${url.includes('?') ? '&' : '?'}source=${gridSource}`,
-                      );
+
+                      // selectedAlbumId가 null일 경우 전체사진 앨범이므로 albumId는 allPhotosAlbumId
+                      const albumId = selectedAlbumId ?? allPhotosAlbumId;
+
+                      params.set('source', gridSource);
+
+                      if (
+                        viewContext.type === VIEW_CONTEXT_TYPE.ALBUM_DETAIL &&
+                        albumId !== null
+                      ) {
+                        params.set('albumId', String(albumId));
+                      }
+
+                      router.push(`${ROUTES.PHOTO.VIEW(photo.id!)}?${params.toString()}`);
                     }}
                   />
                 ),

--- a/apps/web/src/app/_components/MapRoute.tsx
+++ b/apps/web/src/app/_components/MapRoute.tsx
@@ -362,7 +362,6 @@ export default function MapRoute() {
                         photo_date: photo.takenAt ?? '',
                       });
 
-                      const params = new URLSearchParams();
                       const gridSource =
                         viewContext.type === VIEW_CONTEXT_TYPE.ALBUM_DETAIL
                           ? 'album_detail'
@@ -371,16 +370,12 @@ export default function MapRoute() {
                       // selectedAlbumId가 null일 경우 전체사진 앨범이므로 albumId는 allPhotosAlbumId
                       const albumId = selectedAlbumId ?? allPhotosAlbumId;
 
-                      params.set('source', gridSource);
-
-                      if (
-                        viewContext.type === VIEW_CONTEXT_TYPE.ALBUM_DETAIL &&
-                        albumId !== null
-                      ) {
-                        params.set('albumId', String(albumId));
-                      }
-
-                      router.push(`${ROUTES.PHOTO.VIEW(photo.id!)}?${params.toString()}`);
+                      router.push(
+                        ROUTES.PHOTO.VIEW(photo.id!, {
+                          source: gridSource,
+                          ...(albumId !== null ? { albumId } : {}),
+                        }),
+                      );
                     }}
                   />
                 ),

--- a/apps/web/src/constants/routes.ts
+++ b/apps/web/src/constants/routes.ts
@@ -1,3 +1,5 @@
+import { buildUrlWithQueryParams } from '@repo/api-client/src/fetcher';
+
 export const ROUTES = {
   HOME: '/',
   LOGIN: '/login',
@@ -17,21 +19,7 @@ export const ROUTES = {
         albumId?: number;
         source?: string;
       },
-    ) => {
-      const searchParams = new URLSearchParams();
-
-      if (params?.albumId) {
-        searchParams.set('albumId', String(params.albumId));
-      }
-
-      if (params?.source) {
-        searchParams.set('source', params.source);
-      }
-
-      const query = searchParams.toString();
-
-      return query ? `/photo/${photoId}?${query}` : `/photo/${photoId}`;
-    },
+    ) => buildUrlWithQueryParams(`/photo/${photoId}`, params),
     VIEW_WITH_CLUSTER: (photoId: number, clusterId: string) =>
       `/photo/${photoId}?clusterId=${clusterId}`,
   },

--- a/apps/web/src/constants/routes.ts
+++ b/apps/web/src/constants/routes.ts
@@ -11,8 +11,27 @@ export const ROUTES = {
     NOTE: {
       ADD: '/photo/add/note',
     },
-    VIEW: (photoId: number, albumId?: number) =>
-      albumId ? `/photo/${photoId}?albumId=${albumId}` : `/photo/${photoId}`,
+    VIEW: (
+      photoId: number,
+      params?: {
+        albumId?: number;
+        source?: string;
+      },
+    ) => {
+      const searchParams = new URLSearchParams();
+
+      if (params?.albumId) {
+        searchParams.set('albumId', String(params.albumId));
+      }
+
+      if (params?.source) {
+        searchParams.set('source', params.source);
+      }
+
+      const query = searchParams.toString();
+
+      return query ? `/photo/${photoId}?${query}` : `/photo/${photoId}`;
+    },
     VIEW_WITH_CLUSTER: (photoId: number, clusterId: string) =>
       `/photo/${photoId}?clusterId=${clusterId}`,
   },


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #57 

## 🛠 2. 작업 내용

- 격자보기에서 사진 상세로 이동할 때 albumId를 함께 전달하도록 수정
- albumId를 기반으로 사진 목록을 조회하여 사진 상세 하단에 ThumbnailSlider가 노출되도록 수정

## 📌 3. 참고 사항

- 없음

## 👀 4. 리뷰 중점 사항

- [x] selectedAlbumId가 null인 경우 전체사진 앨범으로 판단하여 allPhotosAlbumId를 전달하도록 구현했습니다. allPhotosAlbumId가 null이 될 수 있는 케이스가 있는지 확인 부탁드립니다.
- [x] 전체사진 앨범 및 개별 앨범의 격자보기에서 사진 상세로 이동했을 때, 하단에 해당 앨범의 ThumbnailSlider가 정상적으로 노출되는지 확인 부탁드립니다.

