### PR TITLE
fix: 온보딩 프로필 페이지 초기값 설정 (#62)

### DIFF
--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -11,12 +11,13 @@ export default function OnboardingPage() {
   const router = useRouter();
 
   const { data: myPageData, isLoading } = useGetMyPage();
+  const nickname = myPageData?.myName;
 
   useEffect(() => {
     if (isLoading) return;
 
     const timer = setTimeout(() => {
-      if (myPageData) {
+      if (nickname) {
         router.push(ROUTES.ONBOARDING.CONNECT);
       } else {
         router.push(ROUTES.ONBOARDING.PROFILE);
@@ -24,7 +25,7 @@ export default function OnboardingPage() {
     }, ONBOARDING_START_REDIRECT_DELAY);
 
     return () => clearTimeout(timer);
-  }, [isLoading, myPageData, router]);
+  }, [isLoading, nickname, router]);
 
   return (
     <S.Wrapper>

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -5,17 +5,26 @@ import { useRouter } from 'next/navigation';
 import { ROUTES } from '@/constants/routes';
 import { ONBOARDING_START_REDIRECT_DELAY } from '@/constants/onboarding';
 import * as S from './page.styles';
+import { useGetMyPage } from '@repo/api-client/src/generated';
 
 export default function OnboardingPage() {
   const router = useRouter();
 
+  const { data: myPageData, isLoading } = useGetMyPage();
+
   useEffect(() => {
+    if (isLoading) return;
+
     const timer = setTimeout(() => {
-      router.push(ROUTES.ONBOARDING.PROFILE);
+      if (myPageData) {
+        router.push(ROUTES.ONBOARDING.CONNECT);
+      } else {
+        router.push(ROUTES.ONBOARDING.PROFILE);
+      }
     }, ONBOARDING_START_REDIRECT_DELAY);
 
     return () => clearTimeout(timer);
-  }, [router]);
+  }, [isLoading, myPageData, router]);
 
   return (
     <S.Wrapper>

--- a/apps/web/src/app/onboarding/profile/page.tsx
+++ b/apps/web/src/app/onboarding/profile/page.tsx
@@ -94,6 +94,7 @@ export default function ProfilePage() {
     setProfileData,
     markStepCompleted,
     router,
+    queryClient,
   ]);
 
   const isValid = nickname.trim().length > 0;

--- a/apps/web/src/app/onboarding/profile/page.tsx
+++ b/apps/web/src/app/onboarding/profile/page.tsx
@@ -11,13 +11,19 @@ import { ROUTES } from '@/constants/routes';
 import { track } from '@/lib/analytics';
 import { useTrackPage } from '@/hooks/analytics/useTrackPage';
 import * as S from './page.styles';
+import { getGetMyPageQueryKey, useGetMyPage } from '@repo/api-client/src/generated';
+import { useQueryClient } from '@tanstack/react-query';
 
 export default function ProfilePage() {
   const router = useRouter();
+  const queryClient = useQueryClient();
+
   const [nickname, setNickname] = useState('');
   const [imageFile, setImageFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { data: myPageData } = useGetMyPage();
   const { uploadImage, saveProfile, isUploading } = useProfileUpload();
   const { setProfileData, markStepCompleted, completedSteps } = useOnboardingContext();
 
@@ -37,6 +43,13 @@ export default function ProfilePage() {
       }
     };
   }, [previewUrl]);
+
+  useEffect(() => {
+    if (!myPageData) return;
+
+    setNickname(myPageData.myName ?? '');
+    setPreviewUrl(myPageData.myProfileImageUrl ?? null);
+  }, [myPageData]);
 
   const handleSubmit = useCallback(async () => {
     if (!nickname.trim()) return;
@@ -58,9 +71,14 @@ export default function ProfilePage() {
       // 프로필 저장
       const success = await saveProfile(nickname, uploadedUrl);
       if (success) {
+        await queryClient.invalidateQueries({
+          queryKey: getGetMyPageQueryKey(),
+        });
+
         track('profile_setup_complete', {
           has_profile_image: !!uploadedUrl,
         });
+
         setProfileData({ nickname, profileImageUrl: uploadedUrl });
         markStepCompleted('profile');
         router.push(ROUTES.ONBOARDING.CONNECT);


### PR DESCRIPTION
## 🔗 1. 연관 이슈

- Closes #62 

## 🛠 2. 작업 내용

- 온보딩 프로필 페이지 진입 시 useGetMyPage 데이터를 이용해 닉네임과 프로필 이미지 초기값을 설정하도록 수정
- 프로필 저장 성공 후 my-page 쿼리 캐시를 갱신하도록 수정
- 재진입 시 저장된 프로필 정보가 정상적으로 표시되도록 수정

## 📌 3. 참고 사항

- 프로필 저장 후 my-page 캐시를 갱신하여 최신 데이터를 반영하도록 변경했습니다.

## 👀 4. 리뷰 중점 사항

- [x] 프로필 저장 후 페이지 재진입 시 닉네임 및 프로필 이미지가 정상적으로 표시되는지
